### PR TITLE
refactor: supabase auth

### DIFF
--- a/biblioteca-alejandria/app/registro/RegistroForm.tsx
+++ b/biblioteca-alejandria/app/registro/RegistroForm.tsx
@@ -129,14 +129,11 @@ export default function RegistroForm() {
 
             // TODO: Agregar lógica de subida al servidor aquí
             /*
-            const response = await fetch('/api/registro', {
-                method: 'POST',
-                body: formData // o JSON.stringify(data)
-            });
-            
-            if (!response.ok) {
-                throw new Error('Error al registrar usuario');
-            }
+            Flujo:
+                1. Validar datos del formulario.
+                2. Crear usuario Auth con role CLIENTE.
+                3. Insertar en Usuario con id = auth_user.id.
+                4. Guardar solo datos de perfil (sin correo/password en Usuario).
             */
             
             console.log(data);

--- a/biblioteca-alejandria/app/utils/placesService.ts
+++ b/biblioteca-alejandria/app/utils/placesService.ts
@@ -1,2 +1,0 @@
-const URL = 'https://places.googleapis.com/v1/places:autocomplete';
-

--- a/biblioteca-alejandria/lib/auth/roles.ts
+++ b/biblioteca-alejandria/lib/auth/roles.ts
@@ -1,0 +1,16 @@
+export const ROLES = {
+    ROOT: "ROOT",
+    ADMINISTRADOR: "ADMINISTRADOR",
+    CLIENTE: "CLIENTE",
+} as const;
+
+export type AppRole = (typeof ROLES)[keyof typeof ROLES];
+export const VISITANTE = "VISITANTE" as const;
+
+export function getRoleFromJwtClaims(claims: any): AppRole | typeof VISITANTE {
+    const role = claims?.app_metadata?.role;
+    if (role === ROLES.ROOT || role === ROLES.ADMINISTRADOR || role === ROLES.CLIENTE) {
+        return role;
+    }
+    return VISITANTE;
+}

--- a/biblioteca-alejandria/lib/supabase/admin.ts
+++ b/biblioteca-alejandria/lib/supabase/admin.ts
@@ -1,0 +1,13 @@
+import { createClient } from "@supabase/supabase-js";
+
+export function createAdminClient() {
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+    if (!url) throw new Error("Falta NEXT_PUBLIC_SUPABASE_URL");
+    if (!serviceKey) throw new Error("Falta SUPABASE_SERVICE_ROLE_KEY");
+
+    return createClient(url, serviceKey, {
+        auth: { autoRefreshToken: false, persistSession: false },
+    });
+}


### PR DESCRIPTION
Se modificaron las tablas de Supabase para guardar los datos de autenticación directamente en el auth de supabase en lugar de una tabla en la base de datos. Se actualizó el TODO en RegistroForm.tx. Se agregaro roles.ts y admin.ts, utilidades para gestionar los roles de usuario mediante app_metadata extraida del JWT.