### PR TITLE
refactor(auth): centralizar y mejorar la validación de DNI/Documentos

### DIFF
--- a/biblioteca-alejandria/app/(auth)/register/actions.ts
+++ b/biblioteca-alejandria/app/(auth)/register/actions.ts
@@ -3,6 +3,7 @@
 import { CredentialData, PersonalData, RegisterResponse, Rol } from "@/lib/types/auth";
 import { register } from "@/services/auth/registrationService";
 import { validatePasswordRule } from "@/lib/validations/auth";
+import { validateProfileFields } from "@/lib/validations/profile";
 
 // ─── Validación de entrada ─────────────────────────────────────────
 
@@ -13,55 +14,12 @@ function validateRegistrationData(
   credentialData: CredentialData,
   personalData: PersonalData
 ): Record<string, string> {
-  const errors: Record<string, string> = {};
-
-  // Validar campos obligatorios de datos personales
-  for (const [key, value] of Object.entries(personalData)) {
-    if (
-      key !== "direccion_detalle" &&
-      key !== "direccion_place_id" &&
-      (value === null || value === undefined || value.toString().trim() === "")
-    ) {
-      errors[key] = "Este campo es obligatorio.";
-    }
-  }
+  const errors: Record<string, string> = validateProfileFields(personalData, { requireDni: true });
 
   // Validar campos obligatorios de credenciales
   for (const [key, value] of Object.entries(credentialData)) {
     if (value === null || value === undefined || value.toString().trim() === "") {
       errors[key] = "Este campo es obligatorio.";
-    }
-  }
-
-  // Validaciones específicas
-  if (!errors.dni && personalData.dni.length < 7) {
-    errors.dni = "El DNI debe tener al menos 7 dígitos.";
-  }
-
-  if (!errors.fecha_nacimiento) {
-    const fechaSeleccionada = new Date(personalData.fecha_nacimiento);
-    const hoy = new Date();
-
-    if (Number.isNaN(fechaSeleccionada.getTime())) {
-      errors.fecha_nacimiento = "La fecha de nacimiento no es válida.";
-    } else {
-      let edad = hoy.getFullYear() - fechaSeleccionada.getFullYear();
-      const diferenciaMeses = hoy.getMonth() - fechaSeleccionada.getMonth();
-
-      if (
-        diferenciaMeses < 0 ||
-        (diferenciaMeses === 0 && hoy.getDate() < fechaSeleccionada.getDate())
-      ) {
-        edad--;
-      }
-
-      if (fechaSeleccionada > hoy) {
-        errors.fecha_nacimiento = "No puedes haber nacido en el futuro.";
-      } else if (edad < 18) {
-        errors.fecha_nacimiento = "Debes tener al menos 18 años.";
-      } else if (edad > 80) {
-        errors.fecha_nacimiento = "La edad máxima permitida es 80 años.";
-      }
     }
   }
 
@@ -77,11 +35,6 @@ function validateRegistrationData(
     credentialData.contrasena !== credentialData.confirmar_contrasena
   ) {
     errors.confirmar_contrasena = "Las contraseñas no coinciden.";
-  }
-
-  if (!errors.direccion && !personalData.direccion_place_id) {
-    errors.direccion =
-      "Por favor selecciona una dirección válida de las sugerencias.";
   }
 
   return errors;

--- a/biblioteca-alejandria/lib/validations/profile.ts
+++ b/biblioteca-alejandria/lib/validations/profile.ts
@@ -54,6 +54,15 @@ export function validateProfileFields(
     }
   }
 
+  // Validar formato del DNI si está presente
+  if (!errors.dni && payload.dni) {
+    const dniStr = payload.dni.toString().trim();
+    const dniRegex = /^[A-Za-z0-9]{5,20}$/;
+    if (dniStr.length > 0 && !dniRegex.test(dniStr)) {
+      errors.dni = "El documento debe tener entre 5 y 20 caracteres alfanuméricos.";
+    }
+  }
+
   // Validar fecha de nacimiento
   if (!errors.fecha_nacimiento) {
     const fechaSeleccionada = new Date(payload.fecha_nacimiento);


### PR DESCRIPTION
- Se movió la regla de validación de DNI a la utilidad central [validateProfileFields]
- Se reemplazó la validación manual de longitud mínima por una expresión regular (^[A-Za-z0-9]{5,20}$) que requiere entre 5 y 20 caracteres estrictamente alfanuméricos.
- Se eliminó el código duplicado y manual que evaluaba esto previamente en pp/(auth)/register/actions.ts.