### PR TITLE
refactor: simplificar validación de perfil con garantías de tipos

### DIFF
--- a/biblioteca-alejandria/app/(auth)/register/actions.ts
+++ b/biblioteca-alejandria/app/(auth)/register/actions.ts
@@ -4,7 +4,8 @@ import { CredentialData, PersonalData, RegisterResponse, Rol } from "@/lib/types
 import { register } from "@/services/auth/registrationService";
 import { validatePasswordRule, validateEmail, sanitizeText } from "@/lib/validations/rules";
 import { signIn } from "@/models/authModel";
-import { validateAndSanitizeProfile } from "@/lib/validations/profile";
+import { validateFullProfile } from "@/lib/validations/profile";
+import type { FullProfilePayload } from "@/lib/types/profile";
 
 // ─── Validación de entrada ─────────────────────────────────────────
 
@@ -12,7 +13,21 @@ function validateRegistrationData(
   credentialData: CredentialData,
   personalData: PersonalData
 ): { errors: Record<string, string>; sanitizedPersonal: PersonalData } {
-  const profileResult = validateAndSanitizeProfile(personalData, { requireDni: true });
+  // Construir payload para validación de perfil completo
+  const profilePayload: FullProfilePayload = {
+    dni: personalData.dni,
+    nombres: personalData.nombres,
+    apellidos: personalData.apellidos,
+    fecha_nacimiento: personalData.fecha_nacimiento,
+    lugar_nacimiento: personalData.lugar_nacimiento,
+    genero: personalData.genero,
+    usuario: personalData.usuario,
+    direccion: personalData.direccion,
+    direccion_place_id: personalData.direccion_place_id,
+    direccion_detalle: personalData.direccion_detalle ?? null,
+  };
+
+  const profileResult = validateFullProfile(profilePayload);
   const errors = { ...profileResult.errors };
 
   // Sanitizar y validar email
@@ -45,14 +60,14 @@ function validateRegistrationData(
   // Construir datos personales sanitizados
   const sanitizedPersonal: PersonalData = {
     ...personalData,
-    dni: profileResult.sanitized.dni ?? personalData.dni,
+    dni: profileResult.sanitized.dni,
     nombres: profileResult.sanitized.nombres,
     apellidos: profileResult.sanitized.apellidos,
     fecha_nacimiento: profileResult.sanitized.fecha_nacimiento,
     lugar_nacimiento: profileResult.sanitized.lugar_nacimiento,
     usuario: profileResult.sanitized.usuario,
     direccion: profileResult.sanitized.direccion,
-    direccion_place_id: profileResult.sanitized.direccion_place_id ?? personalData.direccion_place_id,
+    direccion_place_id: profileResult.sanitized.direccion_place_id,
     direccion_detalle: profileResult.sanitized.direccion_detalle ?? undefined,
   };
 

--- a/biblioteca-alejandria/app/completar-perfil/actions.ts
+++ b/biblioteca-alejandria/app/completar-perfil/actions.ts
@@ -3,7 +3,7 @@
 import { getCurrentUser } from "@/models/authModel";
 import type { Genero } from "@/lib/types/auth";
 import type { ProfileUpdateResponse } from "@/lib/types/profile";
-import { validateAndSanitizeProfile } from "@/lib/validations/profile";
+import { validateFullProfile } from "@/lib/validations/profile";
 import { validatePasswordRule } from "@/lib/validations/rules";
 import { completeAdminProfile } from "@/services/profile/completeProfileService";
 
@@ -23,25 +23,22 @@ export async function completarPerfilAction(
     };
   }
 
-  // 2. Extraer y validar campos
+  // 2. Extraer y validar campos del perfil completo
   const nueva_contrasena = formData.get("nueva_contrasena") as string;
   const confirmar_contrasena = formData.get("confirmar_contrasena") as string;
 
-  const { errors: profileErrors, sanitized } = validateAndSanitizeProfile(
-    {
-      dni: formData.get("dni") as string,
-      nombres: formData.get("nombres") as string,
-      apellidos: formData.get("apellidos") as string,
-      fecha_nacimiento: formData.get("fecha_nacimiento") as string,
-      lugar_nacimiento: formData.get("lugar_nacimiento") as string,
-      genero: formData.get("genero") as Genero,
-      usuario: formData.get("usuario") as string,
-      direccion: formattedAddress,
-      direccion_place_id: placeId,
-      direccion_detalle: (formData.get("direccion_detalle") as string | null) || null,
-    },
-    { requireDni: true }
-  );
+  const { errors: profileErrors, sanitized } = validateFullProfile({
+    dni: formData.get("dni") as string,
+    nombres: formData.get("nombres") as string,
+    apellidos: formData.get("apellidos") as string,
+    fecha_nacimiento: formData.get("fecha_nacimiento") as string,
+    lugar_nacimiento: formData.get("lugar_nacimiento") as string,
+    genero: formData.get("genero") as Genero,
+    usuario: formData.get("usuario") as string,
+    direccion: formattedAddress,
+    direccion_place_id: placeId,
+    direccion_detalle: (formData.get("direccion_detalle") as string | null) || null,
+  });
 
   // 3. Validar contraseñas
   if (!nueva_contrasena) {
@@ -64,7 +61,7 @@ export async function completarPerfilAction(
   // 4. Delegar al servicio con datos sanitizados
   try {
     return await completeAdminProfile({
-      dni: sanitized.dni!,
+      dni: sanitized.dni,
       nombres: sanitized.nombres,
       apellidos: sanitized.apellidos,
       fecha_nacimiento: sanitized.fecha_nacimiento,
@@ -72,7 +69,7 @@ export async function completarPerfilAction(
       genero: sanitized.genero as Genero,
       usuario: sanitized.usuario,
       direccion: sanitized.direccion,
-      direccion_place_id: sanitized.direccion_place_id!,
+      direccion_place_id: sanitized.direccion_place_id,
       direccion_detalle: sanitized.direccion_detalle,
       nueva_contrasena,
     });

--- a/biblioteca-alejandria/app/perfil/PerfilClient.tsx
+++ b/biblioteca-alejandria/app/perfil/PerfilClient.tsx
@@ -139,11 +139,6 @@ export default function PerfilClient({ profileData, isCliente }: PerfilClientPro
                         onFormattedAddressSelect={(addressText) => setFormattedAddress(addressText)}
                     />
 
-                    {/* Mantener valores de campos deshabilitados en el FormData */}
-                    <input type="hidden" name="dni" value={profileData.dni} />
-                    <input type="hidden" name="fecha_nacimiento" value={profileData.fecha_nacimiento} />
-                    <input type="hidden" name="lugar_nacimiento" value={profileData.lugar_nacimiento} />
-
                     {/* Datos de acceso */}
                     <fieldset className="space-y-5">
                         <legend className="text-base md:text-lg font-bold text-brand-primary uppercase tracking-widest pb-2 border-b border-brand-secondary/30 w-full">

--- a/biblioteca-alejandria/app/perfil/actions.ts
+++ b/biblioteca-alejandria/app/perfil/actions.ts
@@ -3,7 +3,7 @@
 import { getCurrentUser } from "@/models/authModel";
 import type { Genero } from "@/lib/types/auth";
 import type { ProfileUpdatePayload, ProfileUpdateResponse } from "@/lib/types/profile";
-import { validateAndSanitizeProfile } from "@/lib/validations/profile";
+import { validateProfileUpdate } from "@/lib/validations/profile";
 import { updateProfile } from "@/services/profile/profileService";
 import { revalidatePath } from "next/cache";
 
@@ -23,12 +23,10 @@ export async function updateProfileAction(
     };
   }
 
-  // 2. Validar y sanitizar
-  const { errors, sanitized } = validateAndSanitizeProfile({
+  // 2. Validar y sanitizar solo campos editables
+  const { errors, sanitized } = validateProfileUpdate({
     nombres: formData.get("nombres") as string,
     apellidos: formData.get("apellidos") as string,
-    fecha_nacimiento: formData.get("fecha_nacimiento") as string,
-    lugar_nacimiento: formData.get("lugar_nacimiento") as string,
     genero: formData.get("genero") as Genero,
     usuario: formData.get("usuario") as string,
     direccion: formattedAddress,
@@ -40,18 +38,8 @@ export async function updateProfileAction(
     return { success: false, errors };
   }
 
-  // 3. Construir payload con datos sanitizados
-  const payload: ProfileUpdatePayload = {
-    nombres: sanitized.nombres,
-    apellidos: sanitized.apellidos,
-    fecha_nacimiento: sanitized.fecha_nacimiento,
-    lugar_nacimiento: sanitized.lugar_nacimiento,
-    genero: sanitized.genero as Genero,
-    usuario: sanitized.usuario,
-    direccion: sanitized.direccion,
-    direccion_place_id: sanitized.direccion_place_id!,
-    direccion_detalle: sanitized.direccion_detalle ?? null,
-  };
+  // 3. Construir payload con datos sanitizados (ya tipado correctamente)
+  const payload: ProfileUpdatePayload = sanitized;
 
   // 4. Delegar al servicio
   try {

--- a/biblioteca-alejandria/lib/types/profile.ts
+++ b/biblioteca-alejandria/lib/types/profile.ts
@@ -38,8 +38,12 @@ export interface UserProfileData {
 
 // ─── Payloads de Validación y Actualización ──────────────────────────
 
-export interface ProfileFieldsPayload {
-  dni?: string;
+/**
+ * Payload completo para registro y onboarding.
+ * Incluye todos los campos del perfil, incluyendo los inmutables.
+ */
+export interface FullProfilePayload {
+  dni: string;
   nombres: string;
   apellidos: string;
   fecha_nacimiento: string;
@@ -47,29 +51,34 @@ export interface ProfileFieldsPayload {
   genero: Genero | string;
   usuario: string;
   direccion: string;
-  direccion_place_id?: string;
+  direccion_place_id: string;
   direccion_detalle?: string | null;
 }
 
-/** Resultado con datos sanitizados + errores. */
-export interface ProfileValidationResult {
-  errors: Record<string, string>;
-  sanitized: ProfileFieldsPayload;
-}
-
-/** Datos enviados para actualizar el perfil. Excluye `dni` y `correo`. */
+/**
+ * Payload para actualización de perfil.
+ * Excluye campos inmutables: `dni`, `fecha_nacimiento`, `lugar_nacimiento`.
+ */
 export interface ProfileUpdatePayload {
   nombres: string;
   apellidos: string;
-  fecha_nacimiento: string;
-  lugar_nacimiento: string;
   genero: Genero;
   usuario: string;
-
-  // Dirección
   direccion: string;
   direccion_place_id: string;
   direccion_detalle?: string | null;
+}
+
+/** Resultado de validación con datos sanitizados + errores. */
+export interface FullProfileValidationResult {
+  errors: Record<string, string>;
+  sanitized: FullProfilePayload;
+}
+
+/** Resultado de validación para actualización de perfil. */
+export interface ProfileUpdateValidationResult {
+  errors: Record<string, string>;
+  sanitized: ProfileUpdatePayload;
 }
 
 // ─── Respuesta del server action ───────────────────────────────────

--- a/biblioteca-alejandria/lib/validations/profile.ts
+++ b/biblioteca-alejandria/lib/validations/profile.ts
@@ -1,33 +1,83 @@
 import {
   sanitizeText,
-  validateRequiredString,
-  validateMaxLength,
-  validateUsername,
+  validateFieldRules,
+  requiredRule,
+  maxLengthRule,
+  dniRule,
+  usernameRule,
+  ageRule,
+  placeIdRequiredRule,
+  type ValidationRule,
   MAX_NOMBRE,
   MAX_APELLIDO,
-  MAX_USUARIO,
-  MAX_DNI,
-  MIN_DNI,
   MAX_DIRECCION_DETALLE,
 } from "./rules";
 
-import type { ProfileFieldsPayload, ProfileValidationResult } from "@/lib/types/profile";
+import type {
+  FullProfilePayload,
+  FullProfileValidationResult,
+  ProfileUpdatePayload,
+  ProfileUpdateValidationResult,
+} from "@/lib/types/profile";
 
+// ─── Configuración de campos ───────────────────────────────────────
 
-/**
- * Versión completa que retorna tanto errores como datos sanitizados.
- */
-export function validateAndSanitizeProfile(
-  payload: ProfileFieldsPayload,
-  options: { requireDni?: boolean } = {}
-): ProfileValidationResult {
-  const errors: Record<string, string> = {};
-  const { requireDni = false } = options;
+interface FieldConfig {
+  label: string;
+  rules: ValidationRule[];
+  optional?: boolean;
+}
 
-  // Sanitizar todos los campos de texto
-  const sanitized: ProfileFieldsPayload = {
-    ...payload,
-    dni: payload.dni ? sanitizeText(payload.dni) : payload.dni,
+// Campos compartidos entre ambas validaciones
+const sharedFieldConfigs: Record<string, FieldConfig> = {
+  nombres: {
+    label: "Nombres",
+    rules: [requiredRule("Nombres"), maxLengthRule(MAX_NOMBRE, "Nombres")],
+  },
+  apellidos: {
+    label: "Apellidos",
+    rules: [requiredRule("Apellidos"), maxLengthRule(MAX_APELLIDO, "Apellidos")],
+  },
+  genero: {
+    label: "Género",
+    rules: [requiredRule("Género")],
+  },
+  usuario: {
+    label: "Nombre de usuario",
+    rules: [requiredRule("Nombre de usuario"), usernameRule()],
+  },
+  direccion: {
+    label: "Dirección",
+    rules: [requiredRule("Dirección")],
+  },
+  direccion_detalle: {
+    label: "Detalle de la dirección",
+    rules: [maxLengthRule(MAX_DIRECCION_DETALLE, "Detalle de la dirección")],
+    optional: true,
+  },
+};
+
+// Campos específicos del perfil completo (registro/onboarding)
+const fullProfileOnlyFields: Record<string, FieldConfig> = {
+  dni: {
+    label: "DNI",
+    rules: [requiredRule("DNI"), dniRule()],
+  },
+  fecha_nacimiento: {
+    label: "Fecha de nacimiento",
+    rules: [requiredRule("Fecha de nacimiento"), ageRule(18, 80)],
+  },
+  lugar_nacimiento: {
+    label: "Lugar de nacimiento",
+    rules: [requiredRule("Lugar de nacimiento")],
+  },
+};
+
+// ─── Helpers de sanitización ───────────────────────────────────────
+
+function sanitizeFullProfile(payload: FullProfilePayload): FullProfilePayload {
+  return {
+    dni: sanitizeText(payload.dni),
     nombres: sanitizeText(payload.nombres),
     apellidos: sanitizeText(payload.apellidos),
     fecha_nacimiento: payload.fecha_nacimiento?.trim() ?? "",
@@ -35,99 +85,91 @@ export function validateAndSanitizeProfile(
     genero: payload.genero,
     usuario: payload.usuario?.trim() ?? "",
     direccion: sanitizeText(payload.direccion),
-    direccion_place_id: payload.direccion_place_id?.trim(),
+    direccion_place_id: payload.direccion_place_id?.trim() ?? "",
     direccion_detalle: payload.direccion_detalle
       ? sanitizeText(payload.direccion_detalle)
       : payload.direccion_detalle,
   };
+}
 
-  // Campos obligatorios
-  const required: { key: keyof ProfileFieldsPayload; label: string; max?: number }[] = [
-    { key: "nombres", label: "Nombres", max: MAX_NOMBRE },
-    { key: "apellidos", label: "Apellidos", max: MAX_APELLIDO },
-    { key: "fecha_nacimiento", label: "Fecha de nacimiento" },
-    { key: "lugar_nacimiento", label: "Lugar de nacimiento" },
-    { key: "genero", label: "Género" },
-    { key: "usuario", label: "Nombre de usuario", max: MAX_USUARIO },
-    { key: "direccion", label: "Dirección" },
-  ];
+function sanitizeProfileUpdate(payload: ProfileUpdatePayload): ProfileUpdatePayload {
+  return {
+    nombres: sanitizeText(payload.nombres),
+    apellidos: sanitizeText(payload.apellidos),
+    genero: payload.genero,
+    usuario: payload.usuario?.trim() ?? "",
+    direccion: sanitizeText(payload.direccion),
+    direccion_place_id: payload.direccion_place_id?.trim() ?? "",
+    direccion_detalle: payload.direccion_detalle
+      ? sanitizeText(payload.direccion_detalle)
+      : payload.direccion_detalle,
+  };
+}
 
-  if (requireDni) {
-    required.unshift({ key: "dni", label: "DNI", max: MAX_DNI });
+// ─── Helper de validación ──────────────────────────────────────────
+
+function validateFields(
+  sanitized: FullProfilePayload | ProfileUpdatePayload,
+  fieldConfigs: Record<string, FieldConfig>,
+  errors: Record<string, string>
+): void {
+  for (const [key, config] of Object.entries(fieldConfigs)) {
+    const value = (sanitized as unknown as Record<string, unknown>)[key];
+    
+    // Saltar campos opcionales vacíos
+    if (config.optional && !value) continue;
+    
+    const error = validateFieldRules(value, config.rules);
+    if (error) errors[key] = error;
+  }
+}
+
+// ─── Validación para registro y onboarding ─────────────────────────
+
+/**
+ * Valida y sanitiza todos los campos del perfil para registro/onboarding.
+ * Incluye campos inmutables: dni, fecha_nacimiento, lugar_nacimiento.
+ */
+export function validateFullProfile(
+  payload: FullProfilePayload
+): FullProfileValidationResult {
+  const errors: Record<string, string> = {};
+  const sanitized = sanitizeFullProfile(payload);
+
+  // Validar campos específicos del perfil completo
+  validateFields(sanitized, fullProfileOnlyFields, errors);
+
+  // Validar campos compartidos
+  validateFields(sanitized, sharedFieldConfigs, errors);
+
+  // Validar place_id solo si la dirección es válida
+  if (!errors.direccion) {
+    const placeIdError = validateFieldRules(sanitized.direccion_place_id, [placeIdRequiredRule()]);
+    if (placeIdError) errors.direccion = placeIdError;
   }
 
-  for (const { key, label, max } of required) {
-    const value = sanitized[key];
-    const reqError = validateRequiredString(value, label);
-    if (reqError) {
-      errors[key] = reqError;
-    } else if (max && typeof value === "string") {
-      const lenError = validateMaxLength(value, max, label);
-      if (lenError) errors[key] = lenError;
-    }
-  }
+  return { errors, sanitized };
+}
 
-  // Validar formato del DNI
-  if (!errors.dni && sanitized.dni) {
-    const dniStr = sanitized.dni;
-    const dniRegex = /^[A-Za-z0-9]+$/;
-    if (
-      dniStr.length < MIN_DNI ||
-      dniStr.length > MAX_DNI ||
-      !dniRegex.test(dniStr)
-    ) {
-      errors.dni = `El documento debe tener entre ${MIN_DNI} y ${MAX_DNI} caracteres alfanuméricos.`;
-    }
-  }
+// ─── Validación para actualización de perfil ───────────────────────
 
-  // Validar formato del username
-  if (!errors.usuario && sanitized.usuario) {
-    const usernameError = validateUsername(sanitized.usuario);
-    if (usernameError) errors.usuario = usernameError;
-  }
+/**
+ * Valida y sanitiza únicamente los campos editables del perfil.
+ * Excluye campos inmutables: dni, fecha_nacimiento, lugar_nacimiento.
+ */
+export function validateProfileUpdate(
+  payload: ProfileUpdatePayload
+): ProfileUpdateValidationResult {
+  const errors: Record<string, string> = {};
+  const sanitized = sanitizeProfileUpdate(payload);
 
-  // Validar dirección detalle (longitud máxima, campo opcional)
-  if (sanitized.direccion_detalle) {
-    const detError = validateMaxLength(
-      sanitized.direccion_detalle,
-      MAX_DIRECCION_DETALLE,
-      "Detalle de la dirección"
-    );
-    if (detError) errors.direccion_detalle = detError;
-  }
+  // Validar solo campos compartidos (editables)
+  validateFields(sanitized, sharedFieldConfigs, errors);
 
-  // Validar fecha de nacimiento
-  if (!errors.fecha_nacimiento) {
-    const fechaSeleccionada = new Date(sanitized.fecha_nacimiento);
-    const hoy = new Date();
-
-    if (Number.isNaN(fechaSeleccionada.getTime())) {
-      errors.fecha_nacimiento = "La fecha de nacimiento no es válida.";
-    } else {
-      let edad = hoy.getFullYear() - fechaSeleccionada.getFullYear();
-      const diferenciaMeses = hoy.getMonth() - fechaSeleccionada.getMonth();
-
-      if (
-        diferenciaMeses < 0 ||
-        (diferenciaMeses === 0 && hoy.getDate() < fechaSeleccionada.getDate())
-      ) {
-        edad--;
-      }
-
-      if (fechaSeleccionada > hoy) {
-        errors.fecha_nacimiento = "No puedes haber nacido en el futuro.";
-      } else if (edad < 18) {
-        errors.fecha_nacimiento = "Debes tener al menos 18 años.";
-      } else if (edad > 80) {
-        errors.fecha_nacimiento = "La edad máxima permitida es 80 años.";
-      }
-    }
-  }
-
-  // Validar dirección con Google Places
-  if (!errors.direccion && !sanitized.direccion_place_id) {
-    errors.direccion =
-      "Por favor selecciona una dirección válida de las sugerencias.";
+  // Validar place_id solo si la dirección es válida
+  if (!errors.direccion) {
+    const placeIdError = validateFieldRules(sanitized.direccion_place_id, [placeIdRequiredRule()]);
+    if (placeIdError) errors.direccion = placeIdError;
   }
 
   return { errors, sanitized };

--- a/biblioteca-alejandria/lib/validations/rules.ts
+++ b/biblioteca-alejandria/lib/validations/rules.ts
@@ -204,6 +204,16 @@ export function notBlankRule(label: string): ValidationRule {
   };
 }
 
+/** Regla: dirección debe tener place_id de Google Places. */
+export function placeIdRequiredRule(): ValidationRule {
+  return (value: unknown) => {
+    if (!value || (typeof value === "string" && value.trim() === "")) {
+      return "Por favor selecciona una dirección válida de las sugerencias.";
+    }
+    return null;
+  };
+}
+
 // ─── Utilidades de sanitización ────────────────────────────────────
 
 /** Trim + colapsar espacios múltiples internos. */

--- a/biblioteca-alejandria/models/userModel.ts
+++ b/biblioteca-alejandria/models/userModel.ts
@@ -65,15 +65,13 @@ export async function getUserProfileById(
 
 /**
  * Actualiza los campos editables del perfil en la tabla `usuario`.
- * Nunca modifica `dni` ni `id` por diseño.
+ * Campos inmutables (dni, fecha_nacimiento, lugar_nacimiento) solo se establecen en creación.
  */
 export async function updateUserProfile(
   userId: string,
   data: {
     nombres: string;
     apellidos: string;
-    fecha_nacimiento: string;
-    lugar_nacimiento: string;
     genero: Genero;
     id_direccion?: number;
   }
@@ -85,8 +83,6 @@ export async function updateUserProfile(
     .update({
       nombres: data.nombres,
       apellidos: data.apellidos,
-      fecha_nacimiento: data.fecha_nacimiento,
-      lugar_nacimiento: data.lugar_nacimiento,
       genero: data.genero,
       ...(data.id_direccion !== undefined && {
         id_direccion: data.id_direccion,

--- a/biblioteca-alejandria/services/profile/profileService.ts
+++ b/biblioteca-alejandria/services/profile/profileService.ts
@@ -120,8 +120,6 @@ export async function updateProfile(
     const profileResult = await updateUserProfile(userId, {
       nombres: payload.nombres,
       apellidos: payload.apellidos,
-      fecha_nacimiento: payload.fecha_nacimiento,
-      lugar_nacimiento: payload.lugar_nacimiento,
       genero: payload.genero,
       id_direccion: newAddressId,
     });
@@ -151,12 +149,9 @@ export async function updateProfile(
         console.error("Error al actualizar username en auth:", error);
         
         // ROLLBACK: Restaurar perfil y dirección
-        // 1. Revertimos usuario a la dirección original
         await updateUserProfile(userId, {
           nombres: currentProfile.nombres,
           apellidos: currentProfile.apellidos,
-          fecha_nacimiento: currentProfile.fecha_nacimiento,
-          lugar_nacimiento: currentProfile.lugar_nacimiento,
           genero: currentProfile.genero,
           id_direccion: addressId,
         });


### PR DESCRIPTION
Refactorizar la capa de validación para separar lógica según contexto y garantizar
 que campos inmutables (dni, fecha_nacimiento, lugar_nacimiento) nunca sean procesados
 durante actualizaciones.

 CAMBIOS:
 - lib/types/profile.ts
   * Crear FullProfilePayload para registro/onboarding (campos completos)
   * Simplificar ProfileUpdatePayload (excluir campos inmutables)
   * Eliminar ProfileFieldsPayload (reemplazado por tipos específicos)

 - lib/validations/profile.ts
   * Reemplazar validateAndSanitizeProfile por dos funciones enfocadas:
     - validateFullProfile: para registro y onboarding
     - validateProfileUpdate: solo campos editables
   * Configurar validaciones mediante composición de reglas (DRY)

 - lib/validations/rules.ts
   * Agregar placeIdRequiredRule() para validar dirección de Google Places

 - Server actions
   * app/perfil/actions.ts: usar validateProfileUpdate
   * app/completar-perfil/actions.ts: usar validateFullProfile
   * app/(auth)/register/actions.ts: usar validateFullProfile

 - services/profile/profileService.ts
   * Dejar de pasar fecha_nacimiento y lugar_nacimiento al modelo

 - models/userModel.ts
   * Actualizar tipo de updateUserProfile sin campos inmutables

 - app/perfil/PerfilClient.tsx
   * Eliminar <input type='hidden'> innecesarios