### PR TITLE
feat: nuevas validaciones de contraseña + validaciones instantáneas

### DIFF
--- a/biblioteca-alejandria/app/(auth)/password-recovery/PasswordRecoveryForm.tsx
+++ b/biblioteca-alejandria/app/(auth)/password-recovery/PasswordRecoveryForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, FormEvent, useCallback } from "react";
+import { useState, useEffect, FormEvent, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import Stepper from "@/components/ui/Stepper";
@@ -9,12 +9,16 @@ import CodeInput from "@/components/ui/CodeInput";
 import Input from "@/components/ui/Input";
 import Button from "@/components/ui/Button";
 import Alert from "@/components/ui/Alert";
+import PasswordStrengthIndicator from "@/components/ui/PasswordStrengthIndicator";
 import {
   sendRecoveryCode,
   verifyRecoveryCode,
   resetPassword,
 } from "./actions";
 import type { AuthActionResult } from "@/lib/types/auth";
+import { useValidation } from "@/hooks/useValidation";
+import { validatePasswords, isPasswordValid } from "@/lib/validations/auth";
+import { validateFieldRules, requiredRule, matchRule } from "@/lib/validations/rules";
 
 // ─── Constantes ────────────────────────────────────────────────────
 
@@ -165,6 +169,46 @@ export default function PasswordRecoveryForm() {
     return result.success ?? false;
   };
 
+  // ─── Validaciones Hook ─────────────────────────────────────────
+
+  const validateForm = useCallback((v: { new_password: string; confirm_password: string }) => {
+    const errs: Record<string, string> = {};
+    // Usar indicador visual para la contraseña principal, solo validar confirmación
+    const passwordErrors = validatePasswords(v.new_password, v.confirm_password, true);
+    if (passwordErrors) {
+      if (passwordErrors.contrasena) errs.new_password = passwordErrors.contrasena;
+      if (passwordErrors.confirmar_contrasena) errs.confirm_password = passwordErrors.confirmar_contrasena;
+    }
+    return errs;
+  }, []);
+
+  const { values, errors, handleChange, handleBlur, setErrors, touched } = useValidation(
+    { new_password: "", confirm_password: "" },
+    validateForm,
+    {
+      onFieldChange: () => clearMessages()
+    }
+  );
+
+  useEffect(() => {
+    if (touched.confirm_password) {
+      const confirmError = validateFieldRules(values.confirm_password, [
+        requiredRule("Confirmar contraseña"),
+        matchRule(() => values.new_password, "Las contraseñas no coinciden.")
+      ]);
+      setErrors(prev => {
+        if (confirmError) {
+          if (prev.confirm_password === confirmError) return prev;
+          return { ...prev, confirm_password: confirmError };
+        } else {
+          if (!prev.confirm_password) return prev;
+          const { confirm_password, ...rest } = prev;
+          return rest;
+        }
+      });
+    }
+  }, [values.new_password, values.confirm_password, touched.confirm_password, setErrors]);
+
   // ─── Step 1: Enviar código ────────────────────────────────────
 
   const handleStepOne = async (e: FormEvent<HTMLFormElement>) => {
@@ -228,18 +272,22 @@ export default function PasswordRecoveryForm() {
     e.preventDefault();
     clearMessages();
 
-    const fd = new FormData(e.currentTarget);
-    const newPassword = fd.get("new_password") as string;
-    const confirmPassword = fd.get("confirm_password") as string;
+    // Validar con hook antes del submit
+    const validationErrors = validateForm(values);
+    setErrors(validationErrors);
 
-    // Validación client-side rápida (el servidor valida de nuevo)
-    if (newPassword !== confirmPassword) {
-      setError("Las contraseñas no coinciden.");
+    // Verificar que la contraseña sea válida (aunque no genere error visible, bloquear submit)
+    if (!isPasswordValid(values.new_password)) {
+      setError("Por favor, completa todos los requisitos de la contraseña.");
+      return;
+    }
+
+    if (Object.keys(validationErrors).length > 0) {
       return;
     }
 
     setIsPending(true);
-    const result = await resetPassword(newPassword, confirmPassword);
+    const result = await resetPassword(values.new_password, values.confirm_password);
     setIsPending(false);
 
     if (result.success) {
@@ -389,6 +437,7 @@ export default function PasswordRecoveryForm() {
         <form
           onSubmit={handleStepThree}
           autoComplete="off"
+          noValidate
           className="space-y-6"
         >
           <Stepper steps={STEPS} currentStep={3} />
@@ -402,10 +451,13 @@ export default function PasswordRecoveryForm() {
                 type="password"
                 placeholder="••••••••"
                 required
+                value={values.new_password}
+                onChange={(e) => handleChange("new_password", e.target.value)}
+                onBlur={() => handleBlur("new_password")}
               />
-              <span className="text-xs text-brand-accent font-light mt-1 block">
-                Mínimo 8 caracteres.
-              </span>
+              <div className="mt-3">
+                <PasswordStrengthIndicator password={values.new_password} />
+              </div>
             </div>
 
             <Input
@@ -415,12 +467,16 @@ export default function PasswordRecoveryForm() {
               type="password"
               placeholder="••••••••"
               required
+              value={values.confirm_password}
+              onChange={(e) => handleChange("confirm_password", e.target.value)}
+              onBlur={() => handleBlur("confirm_password")}
+              error={errors.confirm_password}
             />
           </div>
 
           <Button
             type="submit"
-            disabled={isPending}
+            disabled={isPending || Object.keys(errors).length > 0}
             className="flex items-center justify-center gap-2"
           >
             {isPending ? (

--- a/biblioteca-alejandria/app/(auth)/register/RegistroForm.tsx
+++ b/biblioteca-alejandria/app/(auth)/register/RegistroForm.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import Input from "@/components/ui/Input";
 import Button from "@/components/ui/Button";
 import Alert from "@/components/ui/Alert";
+import PasswordStrengthIndicator from "@/components/ui/PasswordStrengthIndicator";
 import PersonalDataFields from "@/components/PersonalDataFields";
 import type { CredentialData, PersonalData, Genero } from "@/lib/types/auth";
 import { registerUser } from "./actions";
@@ -21,7 +22,7 @@ import {
     usernameRule,
 } from "@/lib/validations/rules";
 
-import { validatePasswords } from "@/lib/validations/auth";
+import { validatePasswords, isPasswordValid } from "@/lib/validations/auth";
 
 type RegistroFormValues = {
     dni: string;
@@ -80,8 +81,8 @@ export default function RegistroForm() {
         const correoError = validateFieldRules(values.correo, [requiredRule("Correo electrónico"), emailRule()]);
         if (correoError) errors.correo = correoError;
 
-        // Validar contraseña
-        const passwordErrors = validatePasswords(values.contrasena, values.confirmar_contrasena);
+        // Validar contraseña (usar indicador visual)
+        const passwordErrors = validatePasswords(values.contrasena, values.confirmar_contrasena, true);
         if (passwordErrors) {
             Object.assign(errors, passwordErrors);
         }
@@ -170,6 +171,12 @@ export default function RegistroForm() {
         // Validar todo el formulario antes de enviar (incluye campos sin blur)
         const validationErrors = validateForm(values);
         setErrors(validationErrors);
+
+        // Verificar que la contraseña sea válida
+        if (!isPasswordValid(values.contrasena)) {
+            setServerErrors({ form: "Por favor, completa todos los requisitos de la contraseña." });
+            return;
+        }
 
         if (Object.keys(validationErrors).length > 0) {
             return;
@@ -292,11 +299,10 @@ export default function RegistroForm() {
                             value={values.contrasena}
                             onChange={(e) => handleChange("contrasena", e.target.value)}
                             onBlur={() => handleBlur("contrasena")}
-                            error={allErrors.contrasena}
                         />
-                        <span className={`text-xs text-brand-accent font-light mt-1 block ${allErrors.contrasena ? "invisible" : ""}`}>
-                            Mínimo 8 caracteres.
-                        </span>
+                        <div className="mt-3">
+                            <PasswordStrengthIndicator password={values.contrasena} />
+                        </div>
                     </div>
                     <Input
                         id="confirmar_contrasena"

--- a/biblioteca-alejandria/app/(auth)/register/RegistroForm.tsx
+++ b/biblioteca-alejandria/app/(auth)/register/RegistroForm.tsx
@@ -50,6 +50,11 @@ export default function RegistroForm() {
     const validateForm = useCallback((values: RegistroFormValues): Record<string, string> => {
         const errors: Record<string, string> = {};
 
+        // Validar dirección (requerida)
+        if (!formattedAddress) {
+            errors.direccion = "La dirección es obligatoria.";
+        }
+
         // Validar DNI
         const dniError = validateFieldRules(values.dni, [requiredRule("DNI"), dniRule()]);
         if (dniError) errors.dni = dniError;
@@ -88,7 +93,7 @@ export default function RegistroForm() {
         }
 
         return errors;
-    }, []);
+    }, [formattedAddress]);
 
     // Hook de validación con patrón híbrido (blur inicial + onChange en corrección)
     const { values, errors, handleChange, handleBlur, setErrors, touched } = useValidation<RegistroFormValues>(
@@ -299,6 +304,7 @@ export default function RegistroForm() {
                             value={values.contrasena}
                             onChange={(e) => handleChange("contrasena", e.target.value)}
                             onBlur={() => handleBlur("contrasena")}
+                            error={allErrors.contrasena}
                         />
                         <div className="mt-3">
                             <PasswordStrengthIndicator password={values.contrasena} />

--- a/biblioteca-alejandria/app/(auth)/register/RegistroForm.tsx
+++ b/biblioteca-alejandria/app/(auth)/register/RegistroForm.tsx
@@ -50,11 +50,6 @@ export default function RegistroForm() {
     const validateForm = useCallback((values: RegistroFormValues): Record<string, string> => {
         const errors: Record<string, string> = {};
 
-        // Validar dirección (requerida)
-        if (!formattedAddress) {
-            errors.direccion = "La dirección es obligatoria.";
-        }
-
         // Validar DNI
         const dniError = validateFieldRules(values.dni, [requiredRule("DNI"), dniRule()]);
         if (dniError) errors.dni = dniError;

--- a/biblioteca-alejandria/app/completar-perfil/CompletarPerfilAdmin.tsx
+++ b/biblioteca-alejandria/app/completar-perfil/CompletarPerfilAdmin.tsx
@@ -50,6 +50,11 @@ export default function CompletarPerfilAdmin() {
     const validateForm = useCallback((values: CompletarPerfilFormValues): Record<string, string> => {
         const errors: Record<string, string> = {};
 
+        // Validar dirección (requerida)
+        if (!formattedAddress) {
+            errors.direccion = "La dirección es obligatoria.";
+        }
+
         // Validar DNI
         const dniError = validateFieldRules(values.dni, [requiredRule("DNI"), dniRule()]);
         if (dniError) errors.dni = dniError;
@@ -79,18 +84,12 @@ export default function CompletarPerfilAdmin() {
 
         // Validar contraseñas (nueva_contrasena y confirmar_contrasena) - usar indicador visual
         const passwordErrors = validatePasswords(values.nueva_contrasena, values.confirmar_contrasena, true);
-        if (passwordErrors) {
-            // Mapear los errores de contrasena → nueva_contrasena
-            if (passwordErrors.contrasena) {
-                errors.nueva_contrasena = passwordErrors.contrasena;
-            }
-            if (passwordErrors.confirmar_contrasena) {
-                errors.confirmar_contrasena = passwordErrors.confirmar_contrasena;
-            }
+        if (passwordErrors?.confirmar_contrasena) {
+            errors.confirmar_contrasena = passwordErrors.confirmar_contrasena;
         }
 
         return errors;
-    }, []);
+    }, [formattedAddress]);
 
     // Hook de validación con patrón híbrido (blur inicial + onChange en corrección)
     const { values, errors, handleChange, handleBlur, setErrors, touched } = useValidation<CompletarPerfilFormValues>(
@@ -323,7 +322,7 @@ export default function CompletarPerfilAdmin() {
                         <Button
                             type="submit"
                             className="w-full sm:w-auto inline-flex items-center justify-center gap-2 h-11 px-8"
-                            disabled={loading || Object.keys(errors).length > 0}
+                            disabled={loading || success || Object.keys(errors).length > 0}
                         >
                             {loading ? (
                                 <>

--- a/biblioteca-alejandria/app/completar-perfil/CompletarPerfilAdmin.tsx
+++ b/biblioteca-alejandria/app/completar-perfil/CompletarPerfilAdmin.tsx
@@ -1,22 +1,161 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import PersonalDataFields from "@/components/PersonalDataFields";
 import Input from "@/components/ui/Input";
 import Button from "@/components/ui/Button";
 import Alert from "@/components/ui/Alert";
+import PasswordStrengthIndicator from "@/components/ui/PasswordStrengthIndicator";
 import { completarPerfilAction } from "./actions";
+import { useValidation } from "@/hooks/useValidation";
+import {
+    validateFieldRules,
+    requiredRule,
+    dniRule,
+    notBlankRule,
+    ageRule,
+    usernameRule,
+    matchRule,
+} from "@/lib/validations/rules";
+import { validatePasswords, isPasswordValid } from "@/lib/validations/auth";
+import type { Genero } from "@/lib/types/auth";
+
+// ─── Tipos ─────────────────────────────────────────────────────────
+
+type CompletarPerfilFormValues = {
+    dni: string;
+    nombres: string;
+    apellidos: string;
+    fecha_nacimiento: string;
+    lugar_nacimiento: string;
+    genero: Genero | "";
+    direccion_detalle: string;
+    usuario: string;
+    nueva_contrasena: string;
+    confirmar_contrasena: string;
+};
 
 // ─── Componente ────────────────────────────────────────────────────
 
 export default function CompletarPerfilAdmin() {
     const router = useRouter();
     const [loading, setLoading] = useState(false);
-    const [errors, setErrors] = useState<Record<string, string>>({});
+    const [serverErrors, setServerErrors] = useState<Record<string, string>>({});
     const [success, setSuccess] = useState(false);
     const [formattedAddress, setFormattedAddress] = useState("");
     const [placeId, setPlaceId] = useState("");
+
+    // Función de validación usando reglas atómicas de rules.ts
+    const validateForm = useCallback((values: CompletarPerfilFormValues): Record<string, string> => {
+        const errors: Record<string, string> = {};
+
+        // Validar DNI
+        const dniError = validateFieldRules(values.dni, [requiredRule("DNI"), dniRule()]);
+        if (dniError) errors.dni = dniError;
+
+        // Validar nombres/apellidos
+        const nombresError = validateFieldRules(values.nombres, [requiredRule("Nombres"), notBlankRule("nombres")]);
+        if (nombresError) errors.nombres = nombresError;
+
+        const apellidosError = validateFieldRules(values.apellidos, [requiredRule("Apellidos"), notBlankRule("apellidos")]);
+        if (apellidosError) errors.apellidos = apellidosError;
+
+        // Validar fecha de nacimiento (18-80 años)
+        const fechaError = validateFieldRules(values.fecha_nacimiento, [requiredRule("Fecha de nacimiento"), ageRule(18, 80)]);
+        if (fechaError) errors.fecha_nacimiento = fechaError;
+
+        // Validar lugar de nacimiento
+        const lugarError = validateFieldRules(values.lugar_nacimiento, [requiredRule("Lugar de nacimiento")]);
+        if (lugarError) errors.lugar_nacimiento = lugarError;
+
+        // Validar género
+        const generoError = validateFieldRules(values.genero, [requiredRule("Género")]);
+        if (generoError) errors.genero = generoError;
+
+        // Validar usuario
+        const usuarioError = validateFieldRules(values.usuario, [requiredRule("Nombre de usuario"), usernameRule()]);
+        if (usuarioError) errors.usuario = usuarioError;
+
+        // Validar contraseñas (nueva_contrasena y confirmar_contrasena) - usar indicador visual
+        const passwordErrors = validatePasswords(values.nueva_contrasena, values.confirmar_contrasena, true);
+        if (passwordErrors) {
+            // Mapear los errores de contrasena → nueva_contrasena
+            if (passwordErrors.contrasena) {
+                errors.nueva_contrasena = passwordErrors.contrasena;
+            }
+            if (passwordErrors.confirmar_contrasena) {
+                errors.confirmar_contrasena = passwordErrors.confirmar_contrasena;
+            }
+        }
+
+        return errors;
+    }, []);
+
+    // Hook de validación con patrón híbrido (blur inicial + onChange en corrección)
+    const { values, errors, handleChange, handleBlur, setErrors, touched } = useValidation<CompletarPerfilFormValues>(
+        {
+            dni: "",
+            nombres: "",
+            apellidos: "",
+            fecha_nacimiento: "",
+            lugar_nacimiento: "",
+            genero: "",
+            direccion_detalle: "",
+            usuario: "",
+            nueva_contrasena: "",
+            confirmar_contrasena: "",
+        },
+        validateForm,
+        {
+            // Callback para limpiar errores del servidor cuando el usuario edita el campo
+            onFieldChange: (field) => {
+                setServerErrors((prev) => {
+                    const { [field]: _, ...rest } = prev;
+                    return rest;
+                });
+            }
+        }
+    );
+
+    // Combinar errores de cliente y servidor
+    const allErrors = { ...errors, ...serverErrors };
+
+    useEffect(() => {
+        if (touched.confirmar_contrasena) {
+            const confirmarError = validateFieldRules(values.confirmar_contrasena, [
+                requiredRule("Confirmar contraseña"),
+                matchRule(() => values.nueva_contrasena, "Las contraseñas no coinciden."),
+            ]);
+
+            setErrors(prev => {
+                if (confirmarError) {
+                    if (prev.confirmar_contrasena === confirmarError) return prev;
+                    return { ...prev, confirmar_contrasena: confirmarError };
+                } else {
+                    if (!prev.confirmar_contrasena) return prev;
+                    const { confirmar_contrasena, ...rest } = prev;
+                    return rest;
+                }
+            });
+        }
+    }, [values.nueva_contrasena, values.confirmar_contrasena, touched.confirmar_contrasena, setErrors]);
+
+    // Validar dirección: si hay formattedAddress debe existir placeId
+    useEffect(() => {
+        if (formattedAddress && !placeId) {
+            setErrors(prev => ({
+                ...prev,
+                direccion: "Por favor selecciona una dirección válida de las sugerencias."
+            }));
+        } else if (allErrors.direccion && placeId) {
+            // Limpiar error si ahora hay placeId válido
+            setErrors(prev => {
+                const { direccion, ...rest } = prev;
+                return rest;
+            });
+        }
+    }, [formattedAddress, placeId, setErrors, allErrors.direccion]);
 
     useEffect(() => {
         if (success) {
@@ -27,12 +166,25 @@ export default function CompletarPerfilAdmin() {
         }
     }, [success, router]);
 
-    const canSubmit = !loading && !success;
-
     const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
+
+        // Validar todo el formulario antes de enviar (incluye campos sin blur)
+        const validationErrors = validateForm(values);
+        setErrors(validationErrors);
+
+        // Verificar que la contraseña sea válida
+        if (!isPasswordValid(values.nueva_contrasena)) {
+            setServerErrors({ form: "Por favor, completa todos los requisitos de la contraseña." });
+            return;
+        }
+
+        if (Object.keys(validationErrors).length > 0) {
+            return;
+        }
+
         setLoading(true);
-        setErrors({});
+        setServerErrors({});
         setSuccess(false);
 
         try {
@@ -42,11 +194,11 @@ export default function CompletarPerfilAdmin() {
             if (response.success) {
                 setSuccess(true);
             } else {
-                setErrors(response.errors || { form: response.message || "Error desconocido" });
+                setServerErrors(response.errors || { form: response.message || "Error desconocido" });
             }
         } catch (err: unknown) {
             console.error(err);
-            setErrors({ form: "Ocurrió un error inesperado." });
+            setServerErrors({ form: "Ocurrió un error inesperado." });
         } finally {
             setLoading(false);
         }
@@ -75,11 +227,11 @@ export default function CompletarPerfilAdmin() {
 
             {/* ── Form Card ── */}
             <div className="bg-white rounded-lg border border-brand-accent/25 shadow-[0_1px_3px_rgba(10,9,8,0.04),0_8px_30px_rgba(10,9,8,0.06)] p-6 md:p-8">
-                <form onSubmit={handleSubmit} className="space-y-8">
+                <form onSubmit={handleSubmit} noValidate className="space-y-8">
 
                     {/* Mensajes de estado */}
-                    {errors.form && (
-                        <Alert variant="error">{errors.form}</Alert>
+                    {allErrors.form && (
+                        <Alert variant="error">{allErrors.form}</Alert>
                     )}
                     {success && (
                         <Alert variant="success">
@@ -89,8 +241,18 @@ export default function CompletarPerfilAdmin() {
 
                     {/* Datos personales */}
                     <PersonalDataFields
-                        errors={errors}
-                        defaultValues={{}}
+                        errors={allErrors}
+                        values={{
+                            dni: values.dni,
+                            nombres: values.nombres,
+                            apellidos: values.apellidos,
+                            fecha_nacimiento: values.fecha_nacimiento,
+                            lugar_nacimiento: values.lugar_nacimiento,
+                            genero: values.genero as Genero,
+                            direccion_detalle: values.direccion_detalle,
+                        }}
+                        onChange={(field, value) => handleChange(field as keyof CompletarPerfilFormValues, value)}
+                        onBlur={(field) => handleBlur(field as keyof CompletarPerfilFormValues)}
                         onPlaceSelect={(selectedPlaceId) => setPlaceId(selectedPlaceId)}
                         onFormattedAddressSelect={(addressText) => setFormattedAddress(addressText)}
                     />
@@ -107,7 +269,10 @@ export default function CompletarPerfilAdmin() {
                                 label="Nombre de usuario"
                                 placeholder="juangarcia"
                                 required
-                                error={errors.usuario}
+                                value={values.usuario}
+                                onChange={(e) => handleChange("usuario", e.target.value)}
+                                onBlur={() => handleBlur("usuario")}
+                                error={allErrors.usuario}
                             />
                         </div>
                     </fieldset>
@@ -127,12 +292,14 @@ export default function CompletarPerfilAdmin() {
                                     placeholder="••••••••"
                                     required
                                     autoComplete="new-password"
-                                    error={errors.nueva_contrasena}
+                                    value={values.nueva_contrasena}
+                                    onChange={(e) => handleChange("nueva_contrasena", e.target.value)}
+                                    onBlur={() => handleBlur("nueva_contrasena")}
                                     disabled={success}
                                 />
-                                <span className={`text-xs text-brand-accent font-light mt-1 block ${errors.nueva_contrasena ? "opacity-0" : "opacity-100"}`}>
-                                    Mínimo 8 caracteres.
-                                </span>
+                                <div className="mt-3">
+                                    <PasswordStrengthIndicator password={values.nueva_contrasena} />
+                                </div>
                             </div>
                             <Input
                                 id="confirmar_contrasena"
@@ -142,7 +309,10 @@ export default function CompletarPerfilAdmin() {
                                 placeholder="••••••••"
                                 required
                                 autoComplete="new-password"
-                                error={errors.confirmar_contrasena}
+                                value={values.confirmar_contrasena}
+                                onChange={(e) => handleChange("confirmar_contrasena", e.target.value)}
+                                onBlur={() => handleBlur("confirmar_contrasena")}
+                                error={allErrors.confirmar_contrasena}
                                 disabled={success}
                             />
                         </div>
@@ -153,7 +323,7 @@ export default function CompletarPerfilAdmin() {
                         <Button
                             type="submit"
                             className="w-full sm:w-auto inline-flex items-center justify-center gap-2 h-11 px-8"
-                            disabled={!canSubmit}
+                            disabled={loading || Object.keys(errors).length > 0}
                         >
                             {loading ? (
                                 <>

--- a/biblioteca-alejandria/components/auth/ChangePasswordModal.tsx
+++ b/biblioteca-alejandria/components/auth/ChangePasswordModal.tsx
@@ -1,13 +1,16 @@
 "use client";
 
 import type React from "react";
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import Modal from "@/components/ui/Modal";
 import Input from "@/components/ui/Input";
 import Button from "@/components/ui/Button";
 import Alert from "@/components/ui/Alert";
+import PasswordStrengthIndicator from "@/components/ui/PasswordStrengthIndicator";
 import { changePasswordAction } from "@/app/actions/authActions";
+import { useValidation } from "@/hooks/useValidation";
+import { validatePasswords, isPasswordValid } from "@/lib/validations/auth";
 
 // ─── Iconos ────────────────────────────────────────────────────────
 
@@ -44,6 +47,14 @@ const spinnerIcon = (
   </svg>
 );
 
+// ─── Tipos ─────────────────────────────────────────────────────────
+
+type ChangePasswordFormValues = {
+  current_password: string;
+  new_password: string;
+  confirm_password: string;
+};
+
 // ─── Componente ────────────────────────────────────────────────────
 
 export default function ChangePasswordModal({
@@ -55,26 +66,63 @@ export default function ChangePasswordModal({
 }) {
   const router = useRouter();
   const [isPending, setIsPending] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [serverError, setServerError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
   const [submitCount, setSubmitCount] = useState(0);
 
+  // Función de validación
+  const validateForm = useCallback((values: ChangePasswordFormValues): Record<string, string> => {
+    const errors: Record<string, string> = {};
+
+    // Validar nueva contraseña y confirmación (usar indicador visual)
+    const passwordErrors = validatePasswords(values.new_password, values.confirm_password, true);
+    if (passwordErrors) {
+      Object.assign(errors, passwordErrors);
+      // Mapear los nombres de campo al formulario actual
+      if (passwordErrors.contrasena) {
+        errors.new_password = passwordErrors.contrasena;
+        delete errors.contrasena;
+      }
+      if (passwordErrors.confirmar_contrasena) {
+        errors.confirm_password = passwordErrors.confirmar_contrasena;
+        delete errors.confirmar_contrasena;
+      }
+    }
+
+    return errors;
+  }, []);
+
+  // Hook de validación
+  const { values, errors, handleChange, handleBlur, setErrors, touched } = useValidation<ChangePasswordFormValues>(
+    {
+      current_password: "",
+      new_password: "",
+      confirm_password: "",
+    },
+    validateForm
+  );
+
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    setError(null);
+    setServerError(null);
     setSuccess(false);
     setSubmitCount((prev) => prev + 1);
 
-    const formData = new FormData(e.currentTarget);
-    const newPassword = formData.get("new_password") as string;
-    const confirmPassword = formData.get("confirm_password") as string;
+    // Validar todo el formulario antes de enviar
+    const validationErrors = validateForm(values);
+    setErrors(validationErrors);
 
-    // Validación client-side rápida
-    if (newPassword !== confirmPassword) {
-      setError("Las contraseñas nuevas no coinciden.");
+    // Verificar que la nueva contraseña sea válida
+    if (!isPasswordValid(values.new_password)) {
+      setServerError("Por favor, completa todos los requisitos de la contraseña.");
       return;
     }
 
+    if (Object.keys(validationErrors).length > 0) {
+      return;
+    }
+
+    const formData = new FormData(e.currentTarget);
     setIsPending(true);
     const result = await changePasswordAction(formData);
     setIsPending(false);
@@ -87,7 +135,7 @@ export default function ChangePasswordModal({
         router.push("/login");
       }, 1500);
     } else {
-      setError(result.error ?? "Error desconocido.");
+      setServerError(result.error ?? "Error desconocido.");
     }
   };
 
@@ -103,13 +151,13 @@ export default function ChangePasswordModal({
         </div>
 
         {/* Alertas */}
-        {error && (
+        {serverError && (
           <Alert
             key={`error-${submitCount}`}
             variant="error"
             className="top-1"
           >
-            {error}
+            {serverError}
           </Alert>
         )}
         {success && (
@@ -132,6 +180,9 @@ export default function ChangePasswordModal({
           required
           autoComplete="current-password"
           disabled={isPending || success}
+          value={values.current_password}
+          onChange={(e) => handleChange("current_password", e.target.value)}
+          onBlur={() => handleBlur("current_password")}
         />
 
         <div>
@@ -144,10 +195,13 @@ export default function ChangePasswordModal({
             required
             autoComplete="new-password"
             disabled={isPending || success}
+            value={values.new_password}
+            onChange={(e) => handleChange("new_password", e.target.value)}
+            onBlur={() => handleBlur("new_password")}
           />
-          <span className="text-xs text-brand-accent font-light mt-1 block">
-            Mínimo 8 caracteres.
-          </span>
+          <div className="mt-3">
+            <PasswordStrengthIndicator password={values.new_password} />
+          </div>
         </div>
 
         <Input
@@ -159,6 +213,10 @@ export default function ChangePasswordModal({
           required
           autoComplete="new-password"
           disabled={isPending || success}
+          value={values.confirm_password}
+          onChange={(e) => handleChange("confirm_password", e.target.value)}
+          onBlur={() => handleBlur("confirm_password")}
+          error={errors.confirm_password}
         />
 
         {/* Botón de envío */}

--- a/biblioteca-alejandria/components/auth/ChangePasswordModal.tsx
+++ b/biblioteca-alejandria/components/auth/ChangePasswordModal.tsx
@@ -74,19 +74,10 @@ export default function ChangePasswordModal({
   const validateForm = useCallback((values: ChangePasswordFormValues): Record<string, string> => {
     const errors: Record<string, string> = {};
 
-    // Validar nueva contraseña y confirmación (usar indicador visual)
+    // Validar confirmación de contraseña (indicador visual maneja la principal)
     const passwordErrors = validatePasswords(values.new_password, values.confirm_password, true);
-    if (passwordErrors) {
-      Object.assign(errors, passwordErrors);
-      // Mapear los nombres de campo al formulario actual
-      if (passwordErrors.contrasena) {
-        errors.new_password = passwordErrors.contrasena;
-        delete errors.contrasena;
-      }
-      if (passwordErrors.confirmar_contrasena) {
-        errors.confirm_password = passwordErrors.confirmar_contrasena;
-        delete errors.confirmar_contrasena;
-      }
+    if (passwordErrors?.confirmar_contrasena) {
+      errors.confirm_password = passwordErrors.confirmar_contrasena;
     }
 
     return errors;

--- a/biblioteca-alejandria/components/ui/PasswordStrengthIndicator.tsx
+++ b/biblioteca-alejandria/components/ui/PasswordStrengthIndicator.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import type React from "react";
+import { useMemo } from "react";
+import { PASSWORD_MIN_LENGTH, PASSWORD_MAX_LENGTH } from "@/lib/validations/rules";
+
+// ─── Tipos ──────────────────────────────────────────────────────────
+
+interface PasswordRequirement {
+  id: string;
+  label: string;
+  met: boolean;
+}
+
+interface PasswordStrengthIndicatorProps {
+  password: string;
+  showRequirements?: boolean;
+  className?: string;
+}
+
+// ─── Helper: validar requisitos usando las reglas reales ───────────
+
+function getPasswordRequirements(password: string): PasswordRequirement[] {
+  // Estas validaciones deben coincidir con passwordRule() en lib/validations/rules.ts
+  return [
+    {
+      id: "length",
+      label: `Al menos ${PASSWORD_MIN_LENGTH} caracteres`,
+      met: password.length >= PASSWORD_MIN_LENGTH && password.length <= PASSWORD_MAX_LENGTH,
+    },
+    {
+      id: "lowercase",
+      label: "Una letra minúscula (a-z)",
+      met: /[a-z]/.test(password),
+    },
+    {
+      id: "uppercase",
+      label: "Una letra mayúscula (A-Z)",
+      met: /[A-Z]/.test(password),
+    },
+    {
+      id: "special",
+      label: "Un dígito o carácter especial",
+      met: /[\d\W]/.test(password),
+    },
+    {
+      id: "no-spaces",
+      label: "Sin espacios en blanco",
+      met: !/\s/.test(password),
+    },
+  ];
+}
+
+function getStrengthLevel(metCount: number, total: number): {
+  level: number;
+  label: string;
+  color: string;
+  bgColor: string;
+} {
+  const percentage = (metCount / total) * 100;
+
+  if (percentage === 0) {
+    return { level: 0, label: "", color: "text-gray-400", bgColor: "bg-gray-300" };
+  }
+  if (percentage < 40) {
+    return { level: 1, label: "Débil", color: "text-red-600", bgColor: "bg-red-500" };
+  }
+  if (percentage < 70) {
+    return { level: 2, label: "Media", color: "text-amber-600", bgColor: "bg-amber-500" };
+  }
+  if (percentage < 100) {
+    return { level: 3, label: "Buena", color: "text-blue-600", bgColor: "bg-blue-500" };
+  }
+  return { level: 4, label: "Excelente", color: "text-green-600", bgColor: "bg-green-500" };
+}
+
+// ─── Iconos ─────────────────────────────────────────────────────────
+
+const CheckIcon: React.FC<{ className?: string }> = ({ className = "" }) => (
+  <svg
+    className={className}
+    viewBox="0 0 20 20"
+    fill="currentColor"
+    aria-hidden="true"
+  >
+    <path
+      fillRule="evenodd"
+      d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+      clipRule="evenodd"
+    />
+  </svg>
+);
+
+// ─── Componente Principal ───────────────────────────────────────────
+
+export default function PasswordStrengthIndicator({
+  password,
+  showRequirements = true,
+  className = "",
+}: PasswordStrengthIndicatorProps) {
+  const requirements = useMemo(
+    () => getPasswordRequirements(password),
+    [password]
+  );
+
+  const metCount = requirements.filter((r) => r.met).length;
+  const total = requirements.length;
+  const strength = getStrengthLevel(metCount, total);
+  const percentage = (metCount / total) * 100;
+
+  // No mostrar nada si no hay contraseña
+  if (!password) {
+    return null;
+  }
+
+  return (
+    <div className={`space-y-3 ${className}`}>
+      {/* Barra de progreso */}
+      <div className="space-y-1.5">
+        <div className="h-2 w-full bg-gray-200 rounded-full overflow-hidden shadow-inner">
+          <div
+            className={`h-full ${strength.bgColor} transition-all duration-500 ease-out transform origin-left`}
+            style={{ 
+              width: `${percentage}%`,
+              animation: 'scaleX 0.5s ease-out'
+            }}
+            role="progressbar"
+            aria-valuenow={metCount}
+            aria-valuemin={0}
+            aria-valuemax={total}
+            aria-label="Fortaleza de la contraseña"
+          />
+        </div>
+        {strength.label && (
+          <p className={`text-xs font-semibold ${strength.color} transition-colors duration-300`}>
+            {strength.label}
+          </p>
+        )}
+      </div>
+
+      {/* Lista de requisitos */}
+      {showRequirements && (
+        <ul className="space-y-2" aria-label="Requisitos de contraseña">
+          {requirements.map((req, index) => (
+            <li
+              key={req.id}
+              className={`flex items-center gap-2 text-xs transition-all duration-300 ${
+                req.met ? "text-green-700 font-medium" : "text-gray-500"
+              }`}
+              style={{
+                animation: req.met ? `slideIn 0.3s ease-out ${index * 0.05}s backwards` : 'none'
+              }}
+            >
+              {req.met ? (
+                <CheckIcon className="size-4 flex-shrink-0 animate-[checkPop_0.3s_ease-out]" />
+              ) : (
+                <span
+                  className="size-4 flex-shrink-0 rounded-full border-2 border-current opacity-40"
+                  aria-hidden="true"
+                />
+              )}
+              <span>{req.label}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <style jsx>{`
+        @keyframes scaleX {
+          from {
+            transform: scaleX(0);
+          }
+          to {
+            transform: scaleX(1);
+          }
+        }
+
+        @keyframes slideIn {
+          from {
+            opacity: 0;
+            transform: translateX(-8px);
+          }
+          to {
+            opacity: 1;
+            transform: translateX(0);
+          }
+        }
+
+        @keyframes checkPop {
+          0% {
+            transform: scale(0);
+            opacity: 0;
+          }
+          50% {
+            transform: scale(1.2);
+          }
+          100% {
+            transform: scale(1);
+            opacity: 1;
+          }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/biblioteca-alejandria/components/ui/PasswordStrengthIndicator.tsx
+++ b/biblioteca-alejandria/components/ui/PasswordStrengthIndicator.tsx
@@ -41,12 +41,12 @@ function getPasswordRequirements(password: string): PasswordRequirement[] {
     {
       id: "special",
       label: "Un dígito o carácter especial",
-      met: /[\d\W]/.test(password),
+      met: /[^\sa-zA-Z]/.test(password),
     },
     {
       id: "no-spaces",
       label: "Sin espacios en blanco",
-      met: !/\s/.test(password),
+      met: password.length > 0 && !/\s/.test(password),
     },
   ];
 }
@@ -62,13 +62,13 @@ function getStrengthLevel(metCount: number, total: number): {
   if (percentage === 0) {
     return { level: 0, label: "", color: "text-gray-400", bgColor: "bg-gray-300" };
   }
-  if (percentage < 40) {
+  if (percentage <= 40) {
     return { level: 1, label: "Débil", color: "text-red-600", bgColor: "bg-red-500" };
   }
-  if (percentage < 70) {
+  if (percentage <= 60) {
     return { level: 2, label: "Media", color: "text-amber-600", bgColor: "bg-amber-500" };
   }
-  if (percentage < 100) {
+  if (percentage <= 80) {
     return { level: 3, label: "Buena", color: "text-blue-600", bgColor: "bg-blue-500" };
   }
   return { level: 4, label: "Excelente", color: "text-green-600", bgColor: "bg-green-500" };
@@ -107,11 +107,6 @@ export default function PasswordStrengthIndicator({
   const total = requirements.length;
   const strength = getStrengthLevel(metCount, total);
   const percentage = (metCount / total) * 100;
-
-  // No mostrar nada si no hay contraseña
-  if (!password) {
-    return null;
-  }
 
   return (
     <div className={`space-y-3 ${className}`}>

--- a/biblioteca-alejandria/lib/validations/auth.ts
+++ b/biblioteca-alejandria/lib/validations/auth.ts
@@ -1,14 +1,38 @@
 import { matchRule, passwordRule, requiredPasswordRule, requiredRule, validateFieldRules } from "./rules";
 
+/**
+ * Verifica si una contraseña cumple todos los requisitos de validación.
+ * Útil para bloquear submit sin generar mensajes de error.
+ * @param password - La contraseña a validar
+ * @returns true si la contraseña es válida, false en caso contrario
+ */
+export function isPasswordValid(password: string): boolean {
+    if (!password) return false;
+    const error = validateFieldRules(password, [requiredPasswordRule(), passwordRule()]);
+    return error === null;
+}
 
-export function validatePasswords(contrasena: string, confirmar_contrasena: string): Record<string, string> | null {
+/**
+ * Valida una contraseña y su confirmación.
+ * @param contrasena - La contraseña principal
+ * @param confirmar_contrasena - La confirmación de la contraseña
+ * @param useIndicator - Si es true, NO genera errores para el campo principal (se usa el PasswordStrengthIndicator visual)
+ * @returns Record con errores encontrados o null si no hay errores
+ */
+export function validatePasswords(
+    contrasena: string, 
+    confirmar_contrasena: string,
+    useIndicator: boolean = false
+): Record<string, string> | null {
     const errors: Record<string, string> = {};
 
-// Validar contraseña
-    const contrasenaError = validateFieldRules(contrasena, [requiredPasswordRule(), passwordRule()]);
-    if (contrasenaError) errors.contrasena = contrasenaError;
+    // Validar contraseña principal (solo si NO estamos usando el indicador visual)
+    if (!useIndicator) {
+        const contrasenaError = validateFieldRules(contrasena, [requiredPasswordRule(), passwordRule()]);
+        if (contrasenaError) errors.contrasena = contrasenaError;
+    }
 
-    // Validar confirmación de contraseña
+    // Validar confirmación de contraseña (siempre se valida)
     const confirmarError = validateFieldRules(confirmar_contrasena, [
         requiredRule("Confirmar contraseña"),
         matchRule(() => contrasena, "Las contraseñas no coinciden."),

--- a/biblioteca-alejandria/lib/validations/rules.ts
+++ b/biblioteca-alejandria/lib/validations/rules.ts
@@ -130,7 +130,7 @@ export function passwordRule(): ValidationRule {
     }
     
     // Validar al menos un dígito o carácter especial
-    if (!/[\d\W]/.test(value)) {
+    if (!/[^\sa-zA-Z]/.test(value)) {
       return "La contraseña debe contener al menos un dígito o carácter especial.";
     }
     

--- a/biblioteca-alejandria/lib/validations/rules.ts
+++ b/biblioteca-alejandria/lib/validations/rules.ts
@@ -1,7 +1,7 @@
 import { Genero } from "../types/auth";
 // ─── Constantes de validación ──────────────────────────────────────
 
-export const PASSWORD_MIN_LENGTH = 8;
+export const PASSWORD_MIN_LENGTH = 12;
 export const PASSWORD_MAX_LENGTH = 128;
 export const MAX_NOMBRE = 100;
 export const MAX_APELLIDO = 100;
@@ -95,19 +95,50 @@ export function emailRule(): ValidationRule {
   };
 }
 
-/** Regla: contraseña válida (min 8, max 128, sin espacios). */
+/** 
+ * Regla: contraseña válida.
+ * Requisitos:
+ * - Mínimo 12 caracteres
+ * - Al menos una letra minúscula
+ * - Al menos una letra mayúscula
+ * - Al menos un dígito o carácter especial
+ * - Sin espacios en blanco
+ * Regex: /^(?=.*[a-z])(?=.*[A-Z])(?=.*[\d\W])\S{12,}$/
+ */
 export function passwordRule(): ValidationRule {
   return (value: unknown) => {
     if (typeof value !== "string" || !value) return null;
+    
+    // Validar longitud mínima
     if (value.length < PASSWORD_MIN_LENGTH) {
       return `La contraseña debe tener al menos ${PASSWORD_MIN_LENGTH} caracteres.`;
     }
+    
+    // Validar longitud máxima
     if (value.length > PASSWORD_MAX_LENGTH) {
       return `La contraseña no puede exceder ${PASSWORD_MAX_LENGTH} caracteres.`;
     }
+    
+    // Validar al menos una minúscula
+    if (!/[a-z]/.test(value)) {
+      return "La contraseña debe contener al menos una letra minúscula.";
+    }
+    
+    // Validar al menos una mayúscula
+    if (!/[A-Z]/.test(value)) {
+      return "La contraseña debe contener al menos una letra mayúscula.";
+    }
+    
+    // Validar al menos un dígito o carácter especial
+    if (!/[\d\W]/.test(value)) {
+      return "La contraseña debe contener al menos un dígito o carácter especial.";
+    }
+    
+    // Validar sin espacios en blanco
     if (/\s/.test(value)) {
       return "La contraseña no puede contener espacios en blanco.";
     }
+    
     return null;
   };
 }


### PR DESCRIPTION
**Cambios principales:**

Se agregaron las validaciones instantáneas en esta misma rama porque están directamente relacionadas, nos ahorramos merge conflicts.

 lib/validations/auth.ts:
 - Agregar isPasswordValid() helper para validación silenciosa
 - Agregar parámetro useIndicator a validatePasswords() que suprime errores del campo principal
 - Permite elegir entre validación con mensajes de error o solo indicador visual

 components/ui/PasswordStrengthIndicator.tsx:
 - Mejoras visuales: barra con transición suave (scaleX)
 - Checkmarks animados con efecto pop al cumplir requisitos
 - Items con entrada escalonada (slideIn)
 - Colores refinados: rojo → ámbar → azul → verde
 - Tipografía más fuerte cuando requisitos se cumplen

 app/(auth)/password-recovery/PasswordRecoveryForm.tsx:
 - Indicador de fuerza siempre visible, sin condicional
 - Usar isPasswordValid() en handleStepThree para bloquear submit
 - Eliminar error redundante del campo new_password
 - Pasar useIndicator: true a validateForm

 components/auth/ChangePasswordModal.tsx:
 - Indicador de fuerza siempre visible
 - Usar isPasswordValid() en handleSubmit
 - Eliminar condicional !errors.new_password
 - Pasar useIndicator: true a validateForm

 app/(auth)/register/RegistroForm.tsx:
 - Indicador de fuerza siempre visible
 - Usar isPasswordValid() en handleSubmit
 - Eliminar condicional !allErrors.contrasena
 - Pasar useIndicator: true a validateForm

 app/completar-perfil/CompletarPerfilAdmin.tsx:
 - Indicador de fuerza siempre visible
 - Usar isPasswordValid() en handleSubmit
 - Eliminar condicional !allErrors.
 - Pasar useIndicator: true a validateForm

