### PR TITLE
feat:CategoryHU

### DIFF
--- a/biblioteca-alejandria/app/(panel)/panel-admin/categorias/CategoriasContent.tsx
+++ b/biblioteca-alejandria/app/(panel)/panel-admin/categorias/CategoriasContent.tsx
@@ -1,0 +1,292 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Button from "@/components/ui/Button";
+import FilterActionBar from "@/components/ui/FilterActionBar";
+import Alert from "@/components/ui/Alert";
+import { AlertCircle, CheckCircle, Loader2, Plus } from "lucide-react";
+import { useDebounce } from "@/hooks/useDebounce";
+import type {
+  CategoryCreateInput,
+  CategoryWithBookCount,
+} from "@/lib/types/category";
+import type { ActionResponse } from "@/lib/types/common";
+import {
+  createCategoryAction,
+  deleteCategoryAction,
+  getCategoriesAction,
+  searchCategoriesAction,
+  updateCategoryAction,
+} from "./action";
+import CategoriasTable from "./CategoriasTable";
+import CategoryFormModal from "./CategoryFormModal";
+
+export default function CategoriasContent() {
+  const [searchTerm, setSearchTerm] = useState("");
+  const [currentPage, setCurrentPage] = useState(1);
+  const [categoriasData, setCategoriasData] = useState<CategoryWithBookCount[]>([]);
+  const [isLoadingCategorias, setIsLoadingCategorias] = useState(true);
+  const [errorLoadingCategorias, setErrorLoadingCategorias] = useState<string | null>(null);
+  const [totalPages, setTotalPages] = useState(0);
+  const [totalItems, setTotalItems] = useState(0);
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const [editingCategory, setEditingCategory] = useState<CategoryWithBookCount | null>(null);
+  const [deletingId, setDeletingId] = useState<number | null>(null);
+  const [actionResponse, setActionResponse] = useState<ActionResponse | null>(null);
+
+  const itemsPerPage = 10;
+  const debouncedSearchTerm = useDebounce(searchTerm, 700);
+
+  const loadCategories = async (page: number = 1) => {
+    setIsLoadingCategorias(true);
+    setErrorLoadingCategorias(null);
+
+    try {
+      const response = await getCategoriesAction(page, itemsPerPage);
+
+      if (response.success && response.data) {
+        setCategoriasData(response.data.data);
+        setTotalPages(response.data.totalPages);
+        setTotalItems(response.data.total);
+        return;
+      }
+
+      setErrorLoadingCategorias(response.message || "Error al cargar categorías");
+      setCategoriasData([]);
+    } catch (error: unknown) {
+      console.error("Error cargando categorías:", error);
+      setErrorLoadingCategorias("Error inesperado al cargar categorías");
+      setCategoriasData([]);
+    } finally {
+      setIsLoadingCategorias(false);
+    }
+  };
+
+  const refreshCategories = async () => {
+    if (!debouncedSearchTerm.trim()) {
+      await loadCategories(currentPage);
+      return;
+    }
+
+    setIsLoadingCategorias(true);
+    try {
+      const response = await searchCategoriesAction(debouncedSearchTerm);
+      if (response.success && response.data) {
+        setCategoriasData(response.data);
+        setTotalPages(1);
+        setTotalItems(response.data.length);
+      }
+    } catch (error: unknown) {
+      console.error("Error al refrescar búsqueda de categorías:", error);
+    } finally {
+      setIsLoadingCategorias(false);
+    }
+  };
+
+  useEffect(() => {
+    const performSearch = async () => {
+      if (!debouncedSearchTerm.trim()) {
+        await loadCategories(currentPage);
+        return;
+      }
+
+      setIsLoadingCategorias(true);
+      setErrorLoadingCategorias(null);
+
+      try {
+        const response = await searchCategoriesAction(debouncedSearchTerm);
+
+        if (response.success && response.data) {
+          setCategoriasData(response.data);
+          setTotalPages(1);
+          setTotalItems(response.data.length);
+          return;
+        }
+
+        setErrorLoadingCategorias(response.message || "Error al buscar categorías");
+        setCategoriasData([]);
+      } catch (error: unknown) {
+        console.error("Error buscando categorías:", error);
+        setErrorLoadingCategorias("Error inesperado al buscar categorías");
+        setCategoriasData([]);
+      } finally {
+        setIsLoadingCategorias(false);
+      }
+    };
+
+    performSearch();
+  }, [debouncedSearchTerm, currentPage]);
+
+  const handleCreateCategory = async (
+    values: CategoryCreateInput,
+  ): Promise<ActionResponse> => {
+    const response = await createCategoryAction(values);
+    setActionResponse(response);
+    return response;
+  };
+
+  const handleUpdateCategory = async (
+    values: CategoryCreateInput,
+  ): Promise<ActionResponse> => {
+    if (!editingCategory) {
+      return {
+        success: false,
+        errors: { form: "No se encontró una categoría seleccionada para editar." },
+      };
+    }
+
+    const response = await updateCategoryAction(editingCategory.id, {
+      nombre: values.nombre,
+      descripcion: values.descripcion,
+    });
+    setActionResponse(response);
+    return response;
+  };
+
+  const handleDeleteCategory = async (category: CategoryWithBookCount) => {
+    const shouldDelete = window.confirm(
+      `¿Deseas eliminar la categoría "${category.nombre}"?`,
+    );
+
+    if (!shouldDelete) return;
+
+    setDeletingId(category.id);
+    setActionResponse(null);
+
+    try {
+      const response = await deleteCategoryAction(category.id);
+      setActionResponse(response);
+
+      if (!response.success) return;
+
+      if (!debouncedSearchTerm.trim() && categoriasData.length === 1 && currentPage > 1) {
+        setCurrentPage((prev) => prev - 1);
+      } else {
+        await refreshCategories();
+      }
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  const handleSearchChange = (value: string) => {
+    setSearchTerm(value);
+    setCurrentPage(1);
+  };
+
+  const handleCategorySaved = async () => {
+    await refreshCategories();
+  };
+
+  return (
+    <main className="flex-1 w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10 md:py-12 relative">
+      {errorLoadingCategorias && (
+        <Alert
+          variant="error"
+          className="mb-6 flex items-center gap-2 !relative !left-0 !translate-x-0"
+        >
+          <AlertCircle className="w-4 h-4" />
+          {errorLoadingCategorias}
+        </Alert>
+      )}
+
+      {actionResponse?.success && actionResponse.message && (
+        <Alert
+          variant="success"
+          className="mb-6 flex items-center gap-2 !relative !left-0 !translate-x-0"
+          onClose={() => setActionResponse(null)}
+        >
+          <CheckCircle className="w-4 h-4" />
+          {actionResponse.message}
+        </Alert>
+      )}
+
+      {!actionResponse?.success && actionResponse?.message && (
+        <Alert
+          variant="error"
+          className="mb-6 flex items-center gap-2 !relative !left-0 !translate-x-0"
+          onClose={() => setActionResponse(null)}
+        >
+          <AlertCircle className="w-4 h-4" />
+          {actionResponse.message}
+        </Alert>
+      )}
+
+      <div className="flex flex-col md:flex-row md:items-end justify-between gap-6 mb-8 animate-in fade-in slide-in-from-bottom-4 duration-500 ease-out fill-mode-both">
+        <div className="space-y-2">
+          <div className="flex items-center gap-3">
+            <h1 className="text-3xl md:text-4xl font-bold text-brand-primary font-display tracking-tight">
+              Gestión de Categorías
+            </h1>
+            {isLoadingCategorias && (
+              <Loader2 className="w-5 h-5 animate-spin text-brand-primary" />
+            )}
+          </div>
+          <p className="text-brand-secondary text-sm md:text-base max-w-2xl leading-relaxed">
+            Crea, edita y organiza las categorías disponibles para el catálogo de libros.
+            {totalItems > 0 && (
+              <span className="font-semibold text-brand-primary ml-1">
+                ({totalItems} {totalItems === 1 ? "categoría" : "categorías"})
+              </span>
+            )}
+          </p>
+        </div>
+
+        <Button
+          className="flex items-center justify-center gap-2 w-full md:w-auto min-w-56 shadow-lg shadow-brand-primary/20 hover:shadow-brand-primary/30 transition-shadow"
+          onClick={() => setIsCreateModalOpen(true)}
+        >
+          <Plus className="w-4 h-4" />
+          Nueva Categoría
+        </Button>
+      </div>
+
+      <FilterActionBar
+        searchTerm={searchTerm}
+        onSearchChange={handleSearchChange}
+        placeholder="Buscar categorías por nombre..."
+      />
+
+      <div className="animate-in fade-in slide-in-from-bottom-6 duration-700 delay-200 fill-mode-both">
+        <CategoriasTable
+          data={categoriasData}
+          isLoading={isLoadingCategorias}
+          error={null}
+          searchTerm={searchTerm}
+          currentPage={currentPage}
+          totalPages={totalPages}
+          totalItems={totalItems}
+          deletingId={deletingId}
+          onPageChange={setCurrentPage}
+          onEdit={setEditingCategory}
+          onDelete={handleDeleteCategory}
+        />
+      </div>
+
+      <CategoryFormModal
+        isOpen={isCreateModalOpen}
+        title="Nueva Categoría"
+        submitLabel="Crear Categoría"
+        loadingLabel="Creando..."
+        initialValues={{ nombre: "", descripcion: "" }}
+        onClose={() => setIsCreateModalOpen(false)}
+        onSubmit={handleCreateCategory}
+        onSuccess={handleCategorySaved}
+      />
+
+      <CategoryFormModal
+        isOpen={Boolean(editingCategory)}
+        title="Editar Categoría"
+        submitLabel="Guardar Cambios"
+        loadingLabel="Guardando..."
+        initialValues={{
+          nombre: editingCategory?.nombre ?? "",
+          descripcion: editingCategory?.descripcion ?? "",
+        }}
+        onClose={() => setEditingCategory(null)}
+        onSubmit={handleUpdateCategory}
+        onSuccess={handleCategorySaved}
+      />
+    </main>
+  );
+}

--- a/biblioteca-alejandria/app/(panel)/panel-admin/categorias/CategoriasTable.tsx
+++ b/biblioteca-alejandria/app/(panel)/panel-admin/categorias/CategoriasTable.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import Table from "@/components/ui/Table";
+import RowActions from "@/components/ui/RowActions";
+import type { Column } from "@/components/ui/Table";
+import type { CategoryWithBookCount } from "@/lib/types/category";
+import { BookOpen, Loader2, Search, Tag } from "lucide-react";
+
+interface CategoriasTableProps {
+  data: CategoryWithBookCount[];
+  isLoading: boolean;
+  error: string | null;
+  searchTerm: string;
+  currentPage: number;
+  totalPages: number;
+  totalItems: number;
+  deletingId: number | null;
+  onPageChange: (page: number) => void;
+  onEdit: (category: CategoryWithBookCount) => void;
+  onDelete: (category: CategoryWithBookCount) => void;
+}
+
+export default function CategoriasTable({
+  data,
+  isLoading,
+  error,
+  searchTerm,
+  currentPage,
+  totalPages,
+  totalItems,
+  deletingId,
+  onPageChange,
+  onEdit,
+  onDelete,
+}: CategoriasTableProps) {
+  const categoryColumns: Column<CategoryWithBookCount>[] = [
+    {
+      header: "Nombre",
+      render: (item) => (
+        <div className="flex items-center gap-3">
+          <div className="w-10 h-8 rounded-full bg-brand-primary/10 flex items-center justify-center">
+            <Tag className="w-4 h-4 text-brand-primary" />
+          </div>
+          <div className="flex flex-col">
+            <span className="font-semibold text-brand-text">{item.nombre}</span>
+            <span className="text-xs text-brand-secondary/70 lg:hidden">
+              {item.descripcion?.trim() || "Sin descripción"}
+            </span>
+          </div>
+        </div>
+      ),
+    },
+    {
+      header: "Descripción",
+      className: "hidden lg:table-cell whitespace-normal",
+      render: (item) => (
+        <span className="text-sm text-brand-secondary/90 leading-relaxed">
+          {item.descripcion?.trim() || "Sin descripción"}
+        </span>
+      ),
+    },
+    {
+      header: "Libros",
+      render: (item) => (
+        <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-semibold border bg-brand-primary/10 text-brand-primary border-brand-primary/20">
+          <BookOpen className="w-3 h-3" />
+          {item.libro_count}
+        </span>
+      ),
+    },
+    {
+      header: "Acciones",
+      render: (item) => (
+        <RowActions
+          onEdit={() => onEdit(item)}
+          onDelete={() => onDelete(item)}
+          isDeleting={deletingId === item.id}
+          editTitle="Editar categoría"
+          deleteTitle="Eliminar categoría"
+        />
+      ),
+    },
+  ];
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 gap-4">
+        <Loader2 className="w-10 h-10 animate-spin text-brand-primary" />
+        <p className="text-brand-secondary">Cargando categorías...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 gap-4 text-red-600">
+        <p className="font-medium">{error}</p>
+      </div>
+    );
+  }
+
+  const renderEmptyState = () => {
+    if (searchTerm) {
+      return (
+        <div className="flex flex-col items-center justify-center py-12 gap-3 text-brand-secondary/60">
+          <div className="p-3 bg-brand-bg rounded-full">
+            <Search className="w-6 h-6" />
+          </div>
+          <p className="font-medium">No se encontraron categorías</p>
+          <p className="text-xs">Intenta ajustar tu término de búsqueda</p>
+        </div>
+      );
+    }
+
+    return (
+      <div className="flex flex-col items-center justify-center py-12 gap-3 text-brand-secondary/60">
+        <div className="p-3 bg-brand-bg rounded-full">
+          <BookOpen className="w-6 h-6" />
+        </div>
+        <p className="font-medium">No hay categorías registradas</p>
+        <p className="text-xs">
+          Crea la primera categoría con el botón superior
+        </p>
+      </div>
+    );
+  };
+
+  return (
+    <Table
+      data={data}
+      columns={categoryColumns}
+      keyExtractor={(item) => item.id}
+      pagination={{
+        currentPage,
+        totalPages,
+        onPageChange,
+        totalItems,
+      }}
+      emptyMessage={renderEmptyState()}
+    />
+  );
+}

--- a/biblioteca-alejandria/app/(panel)/panel-admin/categorias/CategoryFormModal.tsx
+++ b/biblioteca-alejandria/app/(panel)/panel-admin/categorias/CategoryFormModal.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Button from "@/components/ui/Button";
+import Input from "@/components/ui/Input";
+import Modal from "@/components/ui/Modal";
+import Alert from "@/components/ui/Alert";
+import type { ActionResponse } from "@/lib/types/common";
+import type { CategoryCreateInput } from "@/lib/types/category";
+import { useValidation } from "@/hooks/useValidation";
+import { validateCategory } from "@/lib/validations/category";
+import { sanitizeText } from "@/lib/validations/rules";
+import { Loader2 } from "lucide-react";
+
+interface CategoryFormModalProps {
+  isOpen: boolean;
+  title: string;
+  submitLabel: string;
+  loadingLabel: string;
+  initialValues: CategoryCreateInput;
+  onClose: () => void;
+  onSubmit: (values: CategoryCreateInput) => Promise<ActionResponse>;
+  onSuccess: () => Promise<void> | void;
+}
+
+interface CategoryFormValues extends Record<string, unknown> {
+  nombre: string;
+  descripcion: string;
+}
+
+export default function CategoryFormModal({
+  isOpen,
+  title,
+  submitLabel,
+  loadingLabel,
+  initialValues,
+  onClose,
+  onSubmit,
+  onSuccess,
+}: CategoryFormModalProps) {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [alertState, setAlertState] = useState<ActionResponse | null>(null);
+
+  const validateForm = (values: CategoryFormValues): Record<string, string> =>
+    validateCategory({
+      nombre: sanitizeText(values.nombre),
+    });
+
+  const { values, errors, handleChange, handleBlur, setValues, setErrors } =
+    useValidation<CategoryFormValues>(
+      {
+        nombre: initialValues.nombre,
+        descripcion: initialValues.descripcion ?? "",
+      },
+      validateForm,
+      {
+        onFieldChange: () => {
+          setAlertState(null);
+        },
+      },
+    );
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setValues({
+      nombre: initialValues.nombre,
+      descripcion: initialValues.descripcion ?? "",
+    });
+    setErrors({});
+    setAlertState(null);
+  }, [
+    initialValues.descripcion,
+    initialValues.nombre,
+    isOpen,
+    setErrors,
+    setValues,
+  ]);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setIsSubmitting(true);
+    setErrors({});
+    setAlertState(null);
+
+    try {
+      const sanitizedDescription = sanitizeText(values.descripcion);
+      const payload: CategoryCreateInput = {
+        nombre: sanitizeText(values.nombre),
+        descripcion: sanitizedDescription === "" ? null : sanitizedDescription,
+      };
+
+      const validationErrors = validateCategory({
+        nombre: payload.nombre,
+      });
+
+      if (Object.keys(validationErrors).length > 0) {
+        setErrors(validationErrors);
+        return;
+      }
+
+      const response = await onSubmit(payload);
+
+      setAlertState(response);
+
+      if (response.success) {
+        await onSuccess();
+        onClose();
+        return;
+      }
+
+      setErrors(response.errors ?? {});
+    } catch {
+      setAlertState({
+        success: false,
+        message: "Ocurrió un error inesperado al procesar la categoría.",
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title={title}>
+      <form onSubmit={handleSubmit} className="space-y-5">
+        {alertState?.message && (
+          <Alert
+            variant={alertState.success ? "success" : "error"}
+            className="!relative !left-0 !translate-x-0">
+            {alertState.message}
+          </Alert>
+        )}
+
+        <Input
+          id="category-name"
+          label="Nombre"
+          placeholder="Ej. Novela histórica"
+          value={values.nombre}
+          onChange={(e) => handleChange("nombre", e.target.value)}
+          onBlur={() => handleBlur("nombre")}
+          error={errors.nombre}
+          required
+          disabled={isSubmitting}
+        />
+
+        <Input
+          id="category-description"
+          label="Descripción"
+          placeholder="Describe brevemente la categoría"
+          value={values.descripcion}
+          onChange={(e) => handleChange("descripcion", e.target.value)}
+          onBlur={() => handleBlur("descripcion")}
+          error={errors.descripcion}
+          disabled={isSubmitting}
+        />
+
+        {errors.form && (
+          <p className="text-sm text-red-500 font-medium">{errors.form}</p>
+        )}
+
+        <div className="flex justify-end gap-3 pt-1">
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={onClose}
+            disabled={isSubmitting}
+            className="w-auto px-4 py-1 text-sm">
+            Cancelar
+          </Button>
+          <Button
+            type="submit"
+            disabled={
+              isSubmitting ||
+              Object.keys(errors).length > 0 ||
+              !values.nombre.trim()
+            }
+            className="w-auto px-5 py-1 text-sm flex items-center gap-2">
+            {isSubmitting ? (
+              <>
+                <Loader2 className="w-4 h-4 animate-spin" />
+                {loadingLabel}
+              </>
+            ) : (
+              submitLabel
+            )}
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/biblioteca-alejandria/app/(panel)/panel-admin/categorias/action.ts
+++ b/biblioteca-alejandria/app/(panel)/panel-admin/categorias/action.ts
@@ -1,0 +1,128 @@
+"use server";
+
+import {
+  createCategory,
+  deleteCategory,
+  fetchCategories,
+  searchCategoriesByName,
+  updateCategory,
+} from "@/services/categoryService";
+import { validateCategory } from "@/lib/validations/category";
+import {
+  isValidPositiveInteger,
+  sanitizeNullableText,
+  sanitizeText,
+  toSafePositiveInt,
+} from "@/lib/validations/rules";
+import type {
+  CategoryCreateInput,
+  CategoryUpdateInput,
+  CategoryWithBookCount,
+} from "@/lib/types/category";
+import type { ActionResponse, DataResponse, Paginated } from "@/lib/types/common";
+
+/**
+ * Server Action: obtiene categorías activas paginadas.
+ */
+export async function getCategoriesAction(
+  page: number = 1,
+  pageSize: number = 10,
+): Promise<DataResponse<Paginated<CategoryWithBookCount>>> {
+  const safePage = toSafePositiveInt(page, 1);
+  const safePageSize = toSafePositiveInt(pageSize, 10);
+  return await fetchCategories(safePage, safePageSize);
+}
+
+/**
+ * Server Action: busca categorías activas por nombre.
+ */
+export async function searchCategoriesAction(
+  searchTerm: string,
+): Promise<DataResponse<CategoryWithBookCount[]>> {
+  const cleanTerm = sanitizeText(searchTerm);
+  return await searchCategoriesByName(cleanTerm);
+}
+
+/**
+ * Server Action: crea una categoría.
+ */
+export async function createCategoryAction(
+  input: CategoryCreateInput,
+): Promise<ActionResponse> {
+  const sanitized: CategoryCreateInput = {
+    nombre: sanitizeText(input.nombre),
+    descripcion: sanitizeNullableText(input.descripcion),
+  };
+
+  const errors = validateCategory({ nombre: sanitized.nombre });
+
+  if (Object.keys(errors).length > 0) {
+    return {
+      success: false,
+      errors,
+    };
+  }
+
+  return await createCategory(sanitized);
+}
+
+/**
+ * Server Action: actualiza una categoría existente.
+ */
+export async function updateCategoryAction(
+  categoryId: number,
+  input: CategoryUpdateInput,
+): Promise<ActionResponse> {
+  if (!isValidPositiveInteger(categoryId)) {
+    return {
+      success: false,
+      errors: { form: "El identificador de categoría no es válido." },
+    };
+  }
+
+  const sanitized: CategoryUpdateInput = {};
+
+  if (input.nombre !== undefined) {
+    sanitized.nombre = sanitizeText(input.nombre);
+  }
+
+  if (input.descripcion !== undefined) {
+    sanitized.descripcion = sanitizeNullableText(input.descripcion);
+  }
+
+  if (sanitized.nombre === undefined && sanitized.descripcion === undefined) {
+    return {
+      success: false,
+      errors: { form: "Debes enviar al menos un campo para actualizar." },
+    };
+  }
+
+  const errors = sanitized.nombre !== undefined
+    ? validateCategory({ nombre: sanitized.nombre })
+    : {};
+
+  if (Object.keys(errors).length > 0) {
+    return {
+      success: false,
+      errors,
+    };
+  }
+
+  return await updateCategory(categoryId, sanitized);
+}
+
+/**
+ * Server Action: elimina lógicamente una categoría.
+ */
+export async function deleteCategoryAction(
+  categoryId: number,
+): Promise<ActionResponse> {
+  if (!isValidPositiveInteger(categoryId)) {
+    return {
+      success: false,
+      errors: { form: "El identificador de categoría no es válido." },
+    };
+  }
+
+  return await deleteCategory(categoryId);
+}

--- a/biblioteca-alejandria/app/(panel)/panel-admin/categorias/page.tsx
+++ b/biblioteca-alejandria/app/(panel)/panel-admin/categorias/page.tsx
@@ -1,0 +1,16 @@
+import Navbar from "@/components/Navbar";
+import CategoriasContent from "./CategoriasContent";
+
+export const metadata = {
+  title: "Categorías — Biblioteca de Alejandría",
+  description: "Gestiona las categorías literarias del catálogo.",
+};
+
+export default function GestionCategoriasPage() {
+  return (
+    <div className="min-h-screen bg-brand-bg flex flex-col font-sans">
+      <Navbar />
+      <CategoriasContent />
+    </div>
+  );
+}

--- a/biblioteca-alejandria/components/ui/RowActions.tsx
+++ b/biblioteca-alejandria/components/ui/RowActions.tsx
@@ -13,7 +13,7 @@ interface RowActionsProps {
 
 /**
  * Componente reutilizable para los botones de acción en las filas de las tablas (Editar/Eliminar).
- * 
+ *
  * @param onEdit Callback invocado al hacer click en Editar
  * @param onDelete Callback invocado al hacer click en Eliminar
  * @param isDeleting Indica si la fila está en proceso de eliminación (muestra loader)
@@ -37,8 +37,7 @@ export default function RowActions({
             onEdit();
           }}
           title={editTitle}
-          className="flex items-center justify-center p-2 rounded-lg bg-brand-primary/10 hover:bg-brand-primary/20 text-brand-primary transition-all cursor-pointer ring-1 ring-brand-primary/20 shadow-sm"
-        >
+          className="flex items-center justify-center p-2 rounded-lg bg-brand-primary/10 hover:bg-brand-primary/20 text-brand-primary transition-all cursor-pointer ring-1 ring-brand-primary/20 shadow-sm">
           <Pencil className="w-4 h-4" />
         </button>
       )}
@@ -52,8 +51,7 @@ export default function RowActions({
           }}
           disabled={isDeleting}
           title={deleteTitle}
-          className="flex items-center justify-center p-2 rounded-lg bg-red-500/10 hover:bg-red-500/20 text-red-600 hover:text-red-700 transition-all cursor-pointer ring-1 ring-red-500/20 shadow-sm disabled:opacity-50"
-        >
+          className="flex items-center justify-center p-2 rounded-lg bg-red-500/10 hover:bg-red-500/20 text-red-600 hover:text-red-700 transition-all cursor-pointer ring-1 ring-red-500/20 shadow-sm disabled:opacity-50">
           {isDeleting ? (
             <Loader2 className="w-4 h-4 animate-spin" />
           ) : (

--- a/biblioteca-alejandria/lib/types/category.ts
+++ b/biblioteca-alejandria/lib/types/category.ts
@@ -3,6 +3,11 @@ import type { Database } from "@/lib/types/supabase";
 /** Fila de la tabla `categoria`. */
 export type CategoryRow = Database["public"]["Tables"]["categoria"]["Row"];
 
+/** Categoría con la cantidad de libros asociados (para listados). */
+export interface CategoryWithBookCount extends CategoryRow {
+  libro_count: number;
+}
+
 /** Datos requeridos para crear una categoría. */
 export interface CategoryCreateInput {
   nombre: string;
@@ -14,4 +19,3 @@ export interface CategoryUpdateInput {
   nombre?: string;
   descripcion?: string | null;
 }
-

--- a/biblioteca-alejandria/lib/validations/category.ts
+++ b/biblioteca-alejandria/lib/validations/category.ts
@@ -1,0 +1,25 @@
+import { requiredRule, validateFieldRules } from "./rules";
+
+export interface CategoryValidationPayload {
+  nombre: string;
+}
+
+/**
+ * Valida los datos de una categoría (cliente/servidor).
+ * La sanitización se realiza fuera de este módulo usando utilidades comunes.
+ */
+export function validateCategory(
+  payload: CategoryValidationPayload,
+): Record<string, string> {
+  const errors: Record<string, string> = {};
+
+  const nombreError = validateFieldRules(payload.nombre, [
+    requiredRule("El nombre de la categoría"),
+  ]);
+
+  if (nombreError) {
+    errors.nombre = nombreError;
+  }
+
+  return errors;
+}

--- a/biblioteca-alejandria/lib/validations/rules.ts
+++ b/biblioteca-alejandria/lib/validations/rules.ts
@@ -270,6 +270,26 @@ export function sanitizeText(value: string | null | undefined): string {
   return value.trim().replace(/\s+/g, " ");
 }
 
+/** Sanitiza texto y normaliza nulos/undefined/vacío a null. */
+export function sanitizeNullableText(
+  value: string | null | undefined,
+): string | null {
+  const sanitized = sanitizeText(value);
+  return sanitized === "" ? null : sanitized;
+}
+
+/** Normaliza un número para usarlo como entero positivo seguro con fallback. */
+export function toSafePositiveInt(value: number, fallback: number): number {
+  if (!Number.isFinite(value)) return fallback;
+  const intValue = Math.trunc(value);
+  return intValue > 0 ? intValue : fallback;
+}
+
+/** Valida que el valor sea un entero positivo (ID válido). */
+export function isValidPositiveInteger(value: number): boolean {
+  return Number.isInteger(value) && value > 0;
+}
+
 // ─── Validadores legacy (wrappers para compatibilidad con servidor) ─
 
 /** @deprecated Usar requiredRule(label) en su lugar */

--- a/biblioteca-alejandria/models/categoryModel.ts
+++ b/biblioteca-alejandria/models/categoryModel.ts
@@ -2,10 +2,25 @@ import { createAdminClient } from "@/lib/supabase/server";
 import type {
   CategoryCreateInput,
   CategoryRow,
+  CategoryWithBookCount,
   CategoryUpdateInput,
 } from "@/lib/types/category";
 import type { ModelResult, ModelResultWithId, Paginated } from "@/lib/types/common";
 import { escapeLikePattern, formatILIKE } from "@/lib/validations/db-utils";
+
+function normalizeCategoryWithBookCount(
+  row: CategoryRow & Record<string, unknown>
+): CategoryWithBookCount {
+  const libroArr = row.libro as { count: number }[] | undefined;
+
+  return {
+    id: row.id,
+    nombre: row.nombre,
+    descripcion: row.descripcion,
+    deleted_at: row.deleted_at,
+    libro_count: libroArr?.[0]?.count ?? 0,
+  };
+}
 
 // ─── Operaciones CRUD (sin validaciones de negocio) ─────────────────
 
@@ -44,7 +59,7 @@ export async function createCategory(
 export async function getCategories(
   page: number = 1,
   pageSize: number = 10
-): Promise<Paginated<CategoryRow>> {
+): Promise<Paginated<CategoryWithBookCount>> {
   const adminClient = createAdminClient();
 
   const safePage = Math.max(1, page);
@@ -54,15 +69,19 @@ export async function getCategories(
 
   const { data, error, count } = await adminClient
     .from("categoria")
-    .select("*", { count: "exact" })
+    .select("*, libro(count)", { count: "exact" })
     .is("deleted_at", null)
     .range(from, to)
     .order("id", { ascending: false });
 
   if (error) throw error;
 
+  const normalized = (data ?? []).map((row) =>
+    normalizeCategoryWithBookCount(row as CategoryRow & Record<string, unknown>)
+  );
+
   return {
-    data: data ?? [],
+    data: normalized,
     total: count || 0,
     page: safePage,
     pageSize: safePageSize,
@@ -76,14 +95,14 @@ export async function getCategories(
 export async function searchCategoriesByName(
   searchTerm: string,
   limit: number = 20
-): Promise<CategoryRow[]> {
+): Promise<CategoryWithBookCount[]> {
   const adminClient = createAdminClient();
   const normalizedSearch = formatILIKE(searchTerm);
   const safeLimit = Math.max(1, limit);
 
   const { data, error } = await adminClient
     .from("categoria")
-    .select("*")
+    .select("*, libro(count)")
     .is("deleted_at", null)
     .ilike("nombre", normalizedSearch)
     .order("nombre", { ascending: true })
@@ -94,7 +113,9 @@ export async function searchCategoriesByName(
     throw error;
   }
 
-  return data ?? [];
+  return (data ?? []).map((row) =>
+    normalizeCategoryWithBookCount(row as CategoryRow & Record<string, unknown>)
+  );
 }
 
 /**

--- a/biblioteca-alejandria/services/categoryService.ts
+++ b/biblioteca-alejandria/services/categoryService.ts
@@ -1,0 +1,302 @@
+import {
+  createCategory as createCategoryModel,
+  getCategories as getCategoriesModel,
+  getActiveCategoryByExactName,
+  getActiveCategoryByExactNameExcludingId,
+  getActiveCategoryById,
+  hasActiveBooksForCategory,
+  searchCategoriesByName as searchCategoriesByNameModel,
+  softDeleteCategoryById,
+  updateCategoryById,
+} from "@/models/categoryModel";
+import type {
+  CategoryCreateInput,
+  CategoryWithBookCount,
+  CategoryUpdateInput,
+} from "@/lib/types/category";
+import type {
+  ActionResponse,
+  DataResponse,
+  Paginated,
+} from "@/lib/types/common";
+import { requireAdminRole } from "@/lib/validations/server-auth";
+import { sanitizeNullableText, sanitizeText } from "@/lib/validations/rules";
+
+function normalizeCategoryName(name: string): string {
+  return sanitizeText(name);
+}
+
+function normalizeDescription(
+  description: string | null | undefined,
+): string | null {
+  return sanitizeNullableText(description);
+}
+
+function isSameName(left: string, right: string): boolean {
+  return (
+    normalizeCategoryName(left).toLocaleLowerCase() ===
+    normalizeCategoryName(right).toLocaleLowerCase()
+  );
+}
+
+/**
+ * Obtiene categorías activas paginadas para el panel administrativo.
+ */
+export async function fetchCategories(
+  page: number = 1,
+  pageSize: number = 10,
+): Promise<DataResponse<Paginated<CategoryWithBookCount>>> {
+  try {
+    const roleCheck = await requireAdminRole();
+    if (!roleCheck.success) return roleCheck;
+
+    const data = await getCategoriesModel(page, pageSize);
+    return {
+      success: true,
+      data,
+    };
+  } catch (error: unknown) {
+    console.error("Error inesperado al obtener categorías:", error);
+    const errorMessage =
+      error instanceof Error ? error.message : "Error desconocido";
+    return {
+      success: false,
+      errors: { form: errorMessage },
+      message: "No se pudieron cargar las categorías.",
+    };
+  }
+}
+
+/**
+ * Crea una categoría validando duplicados por nombre.
+ */
+export async function createCategory(
+  input: CategoryCreateInput,
+): Promise<ActionResponse> {
+  const roleCheck = await requireAdminRole();
+  if (!roleCheck.success) return roleCheck;
+
+  try {
+    const normalizedName = normalizeCategoryName(input.nombre ?? "");
+    if (!normalizedName) {
+      return {
+        success: false,
+        errors: { nombre: "El nombre de la categoría es obligatorio." },
+      };
+    }
+
+    const duplicatedCategory =
+      await getActiveCategoryByExactName(normalizedName);
+    if (duplicatedCategory) {
+      return {
+        success: false,
+        errors: { nombre: "Ya existe una categoría con ese nombre." },
+      };
+    }
+
+    const result = await createCategoryModel({
+      nombre: normalizedName,
+      descripcion: normalizeDescription(input.descripcion),
+    });
+
+    if (!result.success) {
+      return {
+        success: false,
+        errors: { form: result.error ?? "No se pudo crear la categoría." },
+        message: "No se pudo crear la categoría.",
+      };
+    }
+
+    return {
+      success: true,
+      message: "Categoría creada exitosamente.",
+    };
+  } catch (error: unknown) {
+    console.error("Error inesperado al crear categoría:", error);
+    const errorMessage =
+      error instanceof Error ? error.message : "Error desconocido";
+    return {
+      success: false,
+      errors: { form: errorMessage },
+      message: "No se pudo crear la categoría.",
+    };
+  }
+}
+
+/**
+ * Edita una categoría activa y valida nombre duplicado cuando cambia.
+ */
+export async function updateCategory(
+  categoryId: number,
+  input: CategoryUpdateInput,
+): Promise<ActionResponse> {
+  const roleCheck = await requireAdminRole();
+  if (!roleCheck.success) return roleCheck;
+
+  try {
+    const currentCategory = await getActiveCategoryById(categoryId);
+    if (!currentCategory) {
+      return {
+        success: false,
+        errors: { form: "La categoría no existe o ya fue eliminada." },
+      };
+    }
+
+    const hasName = input.nombre !== undefined;
+    const hasDescription = input.descripcion !== undefined;
+
+    if (!hasName && !hasDescription) {
+      return {
+        success: false,
+        errors: { form: "Debes enviar al menos un campo para actualizar." },
+      };
+    }
+
+    const payload: CategoryUpdateInput = {};
+
+    if (hasName) {
+      const normalizedName = normalizeCategoryName(input.nombre ?? "");
+
+      if (!normalizedName) {
+        return {
+          success: false,
+          errors: { nombre: "El nombre de la categoría es obligatorio." },
+        };
+      }
+
+      if (!isSameName(normalizedName, currentCategory.nombre)) {
+        const duplicatedCategory =
+          await getActiveCategoryByExactNameExcludingId(
+            normalizedName,
+            categoryId,
+          );
+
+        if (duplicatedCategory) {
+          return {
+            success: false,
+            errors: { nombre: "Ya existe una categoría con ese nombre." },
+          };
+        }
+      }
+
+      payload.nombre = normalizedName;
+    }
+
+    if (hasDescription) {
+      payload.descripcion = normalizeDescription(input.descripcion);
+    }
+
+    const result = await updateCategoryById(categoryId, payload);
+    if (!result.success) {
+      return {
+        success: false,
+        errors: { form: result.error ?? "No se pudo actualizar la categoría." },
+        message: "No se pudo actualizar la categoría.",
+      };
+    }
+
+    return {
+      success: true,
+      message: "Categoría actualizada exitosamente.",
+    };
+  } catch (error: unknown) {
+    console.error("Error inesperado al actualizar categoría:", error);
+    const errorMessage =
+      error instanceof Error ? error.message : "Error desconocido";
+    return {
+      success: false,
+      errors: { form: errorMessage },
+      message: "No se pudo actualizar la categoría.",
+    };
+  }
+}
+
+/**
+ * Elimina lógicamente una categoría activa si no tiene libros asociados.
+ */
+export async function deleteCategory(
+  categoryId: number,
+): Promise<ActionResponse> {
+  const roleCheck = await requireAdminRole();
+  if (!roleCheck.success) return roleCheck;
+
+  try {
+    const currentCategory = await getActiveCategoryById(categoryId);
+    if (!currentCategory) {
+      return {
+        success: false,
+        errors: { form: "La categoría no existe o ya fue eliminada." },
+      };
+    }
+
+    const hasLinkedBooks = await hasActiveBooksForCategory(categoryId);
+    if (hasLinkedBooks) {
+      return {
+        success: false,
+        errors: {
+          form: "No se puede eliminar la categoría porque tiene libros asociados.",
+        },
+      };
+    }
+
+    const result = await softDeleteCategoryById(categoryId);
+    if (!result.success) {
+      return {
+        success: false,
+        errors: { form: result.error ?? "No se pudo eliminar la categoría." },
+        message: "No se pudo eliminar la categoría.",
+      };
+    }
+
+    return {
+      success: true,
+      message: "Categoría eliminada exitosamente.",
+    };
+  } catch (error: unknown) {
+    console.error("Error inesperado al eliminar categoría:", error);
+    const errorMessage =
+      error instanceof Error ? error.message : "Error desconocido";
+    return {
+      success: false,
+      errors: { form: errorMessage },
+      message: "No se pudo eliminar la categoría.",
+    };
+  }
+}
+
+/**
+ * Busca categorías activas por nombre.
+ */
+export async function searchCategoriesByName(
+  searchTerm: string,
+  limit: number = 20,
+): Promise<DataResponse<CategoryWithBookCount[]>> {
+  const roleCheck = await requireAdminRole();
+  if (!roleCheck.success) return roleCheck;
+
+  try {
+    const normalizedSearchTerm = normalizeCategoryName(searchTerm ?? "");
+    if (!normalizedSearchTerm) {
+      return {
+        success: false,
+        errors: { search: "El término de búsqueda no puede estar vacío." },
+        message: "Por favor ingresa un término de búsqueda válido.",
+      };
+    }
+
+    const data = await searchCategoriesByNameModel(normalizedSearchTerm, limit);
+    return {
+      success: true,
+      data,
+    };
+  } catch (error: unknown) {
+    console.error("Error inesperado al buscar categorías:", error);
+    const errorMessage =
+      error instanceof Error ? error.message : "Error desconocido";
+    return {
+      success: false,
+      errors: { form: errorMessage },
+      message: "No se pudo realizar la búsqueda de categorías.",
+    };
+  }
+}


### PR DESCRIPTION
se completa la historia de usuario con vistas, y sus respectivos servicios, en las vistas se usa la tabla generica que se viene trabajando pero se muestran los libros a los que se enlaza esa categoria, por ende se tuvieron que hacer cambios dentro de los types de las categorias, y dentro de su modelo apra traer ese conteo, los actions soportan todos el CRUD. Se agrega ademas el servicio de categoria, permite todos el CRUD , y ademas tiene unas funciones extras que se usan internamente para validaciones sencillas y limpieza, orquesta todas las validaciones de el modelo mediante las funciones añadidas en merge anteriores de los categoryModels. Finalmente se agregan las validaciones para categoria y se reutilizan las que ya existen en rules.ts