### PR TITLE
Refactor de búsquedas: unificación paginada + blindaje global de cara…

### DIFF
--- a/biblioteca-alejandria/app/(panel)/panel-admin/categorias/CategoriasContent.tsx
+++ b/biblioteca-alejandria/app/(panel)/panel-admin/categorias/CategoriasContent.tsx
@@ -15,7 +15,6 @@ import {
   createCategoryAction,
   deleteCategoryAction,
   getCategoriesAction,
-  searchCategoriesAction,
   updateCategoryAction,
 } from "./action";
 import CategoriasTable from "./CategoriasTable";
@@ -37,12 +36,12 @@ export default function CategoriasContent() {
   const itemsPerPage = 10;
   const debouncedSearchTerm = useDebounce(searchTerm, 700);
 
-  const loadCategories = async (page: number = 1) => {
+  const loadCategories = async (page: number = 1, term: string = "") => {
     setIsLoadingCategorias(true);
     setErrorLoadingCategorias(null);
 
     try {
-      const response = await getCategoriesAction(page, itemsPerPage);
+      const response = await getCategoriesAction(page, itemsPerPage, term);
 
       if (response.success && response.data) {
         setCategoriasData(response.data.data);
@@ -62,59 +61,8 @@ export default function CategoriasContent() {
     }
   };
 
-  const refreshCategories = async () => {
-    if (!debouncedSearchTerm.trim()) {
-      await loadCategories(currentPage);
-      return;
-    }
-
-    setIsLoadingCategorias(true);
-    try {
-      const response = await searchCategoriesAction(debouncedSearchTerm);
-      if (response.success && response.data) {
-        setCategoriasData(response.data);
-        setTotalPages(1);
-        setTotalItems(response.data.length);
-      }
-    } catch (error: unknown) {
-      console.error("Error al refrescar búsqueda de categorías:", error);
-    } finally {
-      setIsLoadingCategorias(false);
-    }
-  };
-
   useEffect(() => {
-    const performSearch = async () => {
-      if (!debouncedSearchTerm.trim()) {
-        await loadCategories(currentPage);
-        return;
-      }
-
-      setIsLoadingCategorias(true);
-      setErrorLoadingCategorias(null);
-
-      try {
-        const response = await searchCategoriesAction(debouncedSearchTerm);
-
-        if (response.success && response.data) {
-          setCategoriasData(response.data);
-          setTotalPages(1);
-          setTotalItems(response.data.length);
-          return;
-        }
-
-        setErrorLoadingCategorias(response.message || "Error al buscar categorías");
-        setCategoriasData([]);
-      } catch (error: unknown) {
-        console.error("Error buscando categorías:", error);
-        setErrorLoadingCategorias("Error inesperado al buscar categorías");
-        setCategoriasData([]);
-      } finally {
-        setIsLoadingCategorias(false);
-      }
-    };
-
-    performSearch();
+    loadCategories(currentPage, debouncedSearchTerm);
   }, [debouncedSearchTerm, currentPage]);
 
   const handleCreateCategory = async (
@@ -159,10 +107,10 @@ export default function CategoriasContent() {
 
       if (!response.success) return;
 
-      if (!debouncedSearchTerm.trim() && categoriasData.length === 1 && currentPage > 1) {
+      if (categoriasData.length === 1 && currentPage > 1) {
         setCurrentPage((prev) => prev - 1);
       } else {
-        await refreshCategories();
+        await loadCategories(currentPage, debouncedSearchTerm);
       }
     } finally {
       setDeletingId(null);
@@ -175,7 +123,7 @@ export default function CategoriasContent() {
   };
 
   const handleCategorySaved = async () => {
-    await refreshCategories();
+    await loadCategories(currentPage, debouncedSearchTerm);
   };
 
   return (

--- a/biblioteca-alejandria/app/(panel)/panel-admin/categorias/action.ts
+++ b/biblioteca-alejandria/app/(panel)/panel-admin/categorias/action.ts
@@ -4,9 +4,8 @@ import {
   createCategory,
   deleteCategory,
   fetchCategories,
-  searchCategoriesByName,
   updateCategory,
-} from "@/services/categoryService";
+} from "@/services/categories/categoryService";
 import { validateCategory } from "@/lib/validations/category";
 import {
   isValidPositiveInteger,
@@ -17,9 +16,7 @@ import {
 import type {
   CategoryCreateInput,
   CategoryUpdateInput,
-  CategoryWithBookCount,
   CategoryListResponse,
-  CategorySearchResponse,
   CategoryActionResponse,
 } from "@/lib/types/category";
 
@@ -29,20 +26,12 @@ import type {
 export async function getCategoriesAction(
   page: number = 1,
   pageSize: number = 10,
+  searchTerm?: string,
 ): Promise<CategoryListResponse> {
   const safePage = toSafePositiveInt(page, 1);
   const safePageSize = toSafePositiveInt(pageSize, 10);
-  return await fetchCategories(safePage, safePageSize);
-}
-
-/**
- * Server Action: busca categorías activas por nombre.
- */
-export async function searchCategoriesAction(
-  searchTerm: string,
-): Promise<CategorySearchResponse> {
-  const cleanTerm = sanitizeText(searchTerm);
-  return await searchCategoriesByName(cleanTerm);
+  const cleanTerm = searchTerm ? sanitizeText(searchTerm) : undefined;
+  return await fetchCategories(safePage, safePageSize, cleanTerm);
 }
 
 /**

--- a/biblioteca-alejandria/app/(panel)/panel-root/administradores/AdministradoresContent.tsx
+++ b/biblioteca-alejandria/app/(panel)/panel-root/administradores/AdministradoresContent.tsx
@@ -4,7 +4,7 @@ import Button from "@/components/ui/Button";
 import FilterActionBar from "@/components/ui/FilterActionBar";
 import { Plus, CheckCircle, UserX, Loader2, AlertCircle } from "lucide-react";
 import { useState, useEffect } from "react";
-import { getAdmins, searchAdminsByTerm, habilitarAdministradores, deshabilitarAdministradores  } from "./action";
+import { getAdminUsersAction, habilitarAdministradores, deshabilitarAdministradores  } from "./action";
 import Alert from "@/components/ui/Alert";
 import type { AdminUserFromView } from "@/lib/types/profile";
 import CreateAdminModal from "./CreateAdminModal";
@@ -35,13 +35,13 @@ export default function AdministradoresContent() {
   // Usar el hook de debounce para el término de búsqueda
   const debouncedSearchTerm = useDebounce(searchTerm, 700);
 
-  // Cargar administradores desde el servidor
-  const loadAdmins = async (page: number = 1) => {
+  // Cargar administradores paginados desde el servidor
+  const loadAdmins = async (page: number = 1, term: string = "") => {
     setIsLoadingAdmins(true);
     setErrorLoadingAdmins(null);
     
     try {
-      const response = await getAdmins(page, itemsPerPage);
+      const response = await getAdminUsersAction(page, itemsPerPage, term);
       
       if (response.success && response.data) {
         setAdminsData(response.data.data);
@@ -60,63 +60,9 @@ export default function AdministradoresContent() {
     }
   };
 
-  const refreshAdmins = async () => {
-  if (!debouncedSearchTerm.trim()) {
-    // Si no hay búsqueda, carga normal
-    await loadAdmins(currentPage);
-  } else {
-    // Si hay búsqueda, repite la búsqueda para actualizar los datos
-    setIsLoadingAdmins(true);
-    try {
-      const response = await searchAdminsByTerm(debouncedSearchTerm);
-      if (response.success && response.data) {
-        setAdminsData(response.data);
-        setTotalPages(1);
-        setTotalItems(response.data.length);
-      }
-    } catch (error) {
-      console.error("Error al refrescar búsqueda:", error);
-    } finally {
-      setIsLoadingAdmins(false);
-    }
-  }
-};
-
-  // Cargar o buscar administradores cuando cambie la página o el término de búsqueda
+  // Cargar administradores cuando cambie la página o el término de búsqueda
   useEffect(() => {
-    const performSearch = async () => {
-      if (!debouncedSearchTerm.trim()) {
-        // Si no hay término de búsqueda, cargar la lista paginada completa
-        await loadAdmins(currentPage);
-        return;
-      }
-
-      // Si hay término de búsqueda, realizar búsqueda
-      setIsLoadingAdmins(true);
-      setErrorLoadingAdmins(null);
-
-      try {
-        const response = await searchAdminsByTerm(debouncedSearchTerm);
-        
-        if (response.success && response.data) {
-          setAdminsData(response.data);
-          // Resetear paginación cuando hay búsqueda
-          setTotalPages(1);
-          setTotalItems(response.data.length);
-        } else {
-          setErrorLoadingAdmins(response.message || "Error al buscar administradores");
-          setAdminsData([]);
-        }
-      } catch (error) {
-        console.error("Error buscando administradores:", error);
-        setErrorLoadingAdmins("Error inesperado al buscar administradores");
-        setAdminsData([]);
-      } finally {
-        setIsLoadingAdmins(false);
-      }
-    };
-
-    performSearch();
+    loadAdmins(currentPage, debouncedSearchTerm);
   }, [debouncedSearchTerm, currentPage]);
 
   // Filtrar datos localmente (solo si no hay búsqueda del servidor)
@@ -151,7 +97,7 @@ export default function AdministradoresContent() {
 
       if (result.success) {
         // Recargar la lista de administradores
-        await refreshAdmins();
+        await loadAdmins(currentPage, debouncedSearchTerm);
         
         // Si hay IDs que fallaron, mantenerlos seleccionados
         if (result.errorIds && result.errorIds.length > 0) {
@@ -198,7 +144,7 @@ export default function AdministradoresContent() {
       
       if (result.success) {
         // Recargar la lista de administradores
-        await refreshAdmins();
+        await loadAdmins(currentPage, debouncedSearchTerm);
         
         // Si hay IDs que fallaron, mantenerlos seleccionados
         if (result.errorIds && result.errorIds.length > 0) {
@@ -226,7 +172,7 @@ export default function AdministradoresContent() {
 
   const handleAdminCreated = async () => {
     // Recargar la lista de administradores después de crear uno nuevo
-    await loadAdmins(currentPage);
+    await loadAdmins(currentPage, debouncedSearchTerm);
   };
 
   const handleSearchChange = (value: string) => {

--- a/biblioteca-alejandria/app/(panel)/panel-root/administradores/action.ts
+++ b/biblioteca-alejandria/app/(panel)/panel-root/administradores/action.ts
@@ -1,8 +1,8 @@
 "use server";
 
-import { createAdminAccount, fetchAdminUsers, searchAdmins } from "@/services/admin/adminService";
+import { createAdminAccount, fetchAdminUsers } from "@/services/admin/adminService";
 import { type RegisterResponse, type UserStatusResult } from "@/lib/types/auth";
-import type { AdminUsersResponse, AdminSearchResponse } from "@/lib/types/profile";
+import type { AdminUsersResponse } from "@/lib/types/profile";
 import { deshabilitarUsuario, habilitarUsuario } from "@/services/auth/authService";
 import { sanitizeText, validateEmail, isValidUUID } from "@/lib/validations/rules";
 
@@ -31,24 +31,13 @@ export async function createAdmin(email: string): Promise<RegisterResponse> {
  * @param pageSize - Cantidad de resultados por página
  * @returns Respuesta con datos paginados de administradores
  */
-export async function getAdmins(
+export async function getAdminUsersAction(
     page: number = 1,
-    pageSize: number = 10
+    pageSize: number = 10,
+    searchTerm?: string
 ): Promise<AdminUsersResponse> {
-    return await fetchAdminUsers(page, pageSize);
-}
-
-/**
- * Busca administradores por correo electrónico, nombre o apellidos.
- * 
- * @param searchTerm - Término de búsqueda para filtrar administradores
- * @returns Respuesta con listado de administradores que coinciden con la búsqueda
- */
-export async function searchAdminsByTerm(
-    searchTerm: string
-): Promise<AdminSearchResponse> {
-    const cleanTerm = sanitizeText(searchTerm);
-    return await searchAdmins(cleanTerm);
+    const cleanTerm = searchTerm ? sanitizeText(searchTerm) : undefined;
+    return await fetchAdminUsers(page, pageSize, cleanTerm);
 }
 
 /**

--- a/biblioteca-alejandria/lib/types/category.ts
+++ b/biblioteca-alejandria/lib/types/category.ts
@@ -1,5 +1,5 @@
 import type { Database } from "@/lib/types/supabase";
-import type { ActionResponse, DataResponse, PaginatedResponse } from "./common";
+import type { ActionResponse, PaginatedResponse } from "./common";
 
 /** Fila de la tabla `categoria`. */
 export type CategoryRow = Database["public"]["Tables"]["categoria"]["Row"];
@@ -25,9 +25,6 @@ export interface CategoryUpdateInput {
 
 /** Respuesta de listado de categorías paginada. */
 export type CategoryListResponse = PaginatedResponse<CategoryWithBookCount>;
-
-/** Respuesta para búsqueda de categorías no paginada. */
-export type CategorySearchResponse = DataResponse<CategoryWithBookCount[]>;
 
 /** Respuesta de mutación de categoría (crear/editar/eliminar). */
 export type CategoryActionResponse = ActionResponse;

--- a/biblioteca-alejandria/lib/types/profile.ts
+++ b/biblioteca-alejandria/lib/types/profile.ts
@@ -1,5 +1,5 @@
 import type { Genero } from "./auth";
-import type { ActionResponse, DataResponse, Paginated, PaginatedResponse } from "./common";
+import type { ActionResponse, Paginated, PaginatedResponse } from "./common";
 import type { Database } from "@/lib/types/supabase";
 
 
@@ -111,9 +111,3 @@ export type PaginatedAdminUsers = Paginated<AdminUserFromView>;
  */
 export type AdminUsersResponse = PaginatedResponse<AdminUserFromView>;
 
-// ─── Búsqueda de administradores ─────────────────────────────────────
-
-/**
- * Respuesta de búsqueda de administradores (sin paginación).
- */
-export type AdminSearchResponse = DataResponse<AdminUserFromView[]>;

--- a/biblioteca-alejandria/lib/validations/db-utils.ts
+++ b/biblioteca-alejandria/lib/validations/db-utils.ts
@@ -4,7 +4,23 @@ export function escapeLikePattern(input: string): string {
     return input.trim().replace(/[\\%_]/g, "\\$&");
 }
 
-/** Escapa y envuelve con comodines para búsqueda parcial ILIKE. */
+/** Escapa y envuelve con comodines para búsqueda parcial ILIKE.
+ *  Convierte espacios internos a `%` para tolerar variaciones de espaciado.
+ */
 export function formatILIKE(input: string): string {
-    return `%${escapeLikePattern(input)}%`;
+    const escaped = escapeLikePattern(input);
+    const spaceFlexible = escaped.replace(/\s+/g, "%");
+    return `%${spaceFlexible}%`;
+}
+
+/** Escapa valor para literal entre comillas en filtros lógicos de PostgREST. */
+export function quotePostgrestFilterValue(input: string): string {
+    const escaped = input.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+    return `"${escaped}"`;
+}
+
+/** Construye expresión OR segura para filtros ILIKE multi-columna en PostgREST. */
+export function buildOrILikeFilter(columns: string[], input: string): string {
+    const ilikePattern = quotePostgrestFilterValue(formatILIKE(input));
+    return columns.map((column) => `${column}.ilike.${ilikePattern}`).join(",");
 }

--- a/biblioteca-alejandria/models/authModel.ts
+++ b/biblioteca-alejandria/models/authModel.ts
@@ -5,7 +5,7 @@ import { type AuthActionResult, Rol, type UserStatusResult } from "@/lib/types/a
 import { redirect } from "next/navigation";
 import type { AuthError, AuthResponse } from "@supabase/supabase-js";
 
-import { escapeLikePattern, formatILIKE } from "@/lib/validations/db-utils";
+import { buildOrILikeFilter, escapeLikePattern } from "@/lib/validations/db-utils";
 import type { ModelResult } from "@/lib/types/common";
 import type { AuthSignUpResult } from "@/lib/types/auth";
 import { AdminUserFromView, PaginatedAdminUsers } from "@/lib/types/profile";
@@ -450,7 +450,8 @@ export async function signOutModel(): Promise<AuthError | null> {
  */
 export async function getAdminUsers(
   page: number = 1,
-  pageSize: number = 10
+  pageSize: number = 10,
+  searchTerm?: string
 ): Promise<PaginatedAdminUsers> {
   const adminClient = createAdminClient();
 
@@ -460,12 +461,22 @@ export async function getAdminUsers(
   const from = (safePage - 1) * safePageSize;
   const to = from + safePageSize - 1;
 
-  // ¡Consultamos la VISTA como si fuera una tabla normal!
-  const { data, error, count } = await adminClient
+  let query = adminClient
     .from("vista_administradores") // El nombre que le dimos en SQL
     .select("*", { count: "exact" })
     .range(from, to)
     .order("created_at", { ascending: false });
+
+  if (searchTerm && searchTerm.trim() !== "") {
+    const searchFilter = buildOrILikeFilter(
+      ["email", "nombre_completo"],
+      searchTerm
+    );
+    query = query.or(searchFilter);
+  }
+
+  // ¡Consultamos la VISTA como si fuera una tabla normal!
+  const { data, error, count } = await query;
 
   if (error) throw error;
 
@@ -482,37 +493,6 @@ export async function getAdminUsers(
     pageSize: safePageSize,
     totalPages: Math.ceil((count || 0) / safePageSize),
   };
-}
-
-/**
- * Busca administradores por correo, nombre o apellidos.
- * 
- * @param searchTerm - Término de búsqueda a aplicar en email, nombres o apellidos
- * @returns Listado de administradores que coinciden con el término de búsqueda
- */
-export async function searchAdminUsers(
-  searchTerm: string
-): Promise<AdminUserFromView[]> {
-  const adminClient = createAdminClient();
-
-  const normalizedSearch = formatILIKE(searchTerm);
-
-  const { data, error } = await adminClient
-    .from("vista_administradores")
-    .select("*")
-    .or(
-      `email.ilike.${normalizedSearch},nombre_completo.ilike.${normalizedSearch}`
-    )
-    .order("created_at", { ascending: false });
-
-  if (error) throw error;
-
-  // Filtramos filas con id null
-  const safeData = (data || []).filter(
-    (row): row is AdminUserFromView => row.id !== null
-  );
-
-  return safeData;
 }
 
 // ─── Activación/Desactivación de usuarios ─────────────────────────────

--- a/biblioteca-alejandria/models/authorModel.ts
+++ b/biblioteca-alejandria/models/authorModel.ts
@@ -6,16 +6,9 @@ import type {
   UpdateAuthorPayload,
 } from "@/lib/types/author";
 import { MAX_PAGE_SIZE } from "@/lib/validations/rules";
+import { buildOrILikeFilter, escapeLikePattern } from "@/lib/validations/db-utils";
 
 // ─── Constantes ────────────────────────────────────────────────────
-
-/**
- * Escapa caracteres especiales de PostgREST/ilike (_ y %) para evitar
- * comportamiento de wildcard no intencional.
- */
-function escapeLikeWildcards(value: string): string {
-  return value.replace(/%/g, "\\%").replace(/_/g, "\\_");
-}
 
 // ─── Escritura ─────────────────────────────────────────────────────
 
@@ -117,10 +110,7 @@ export async function getAuthors(
     .order("nombre", { ascending: true });
 
   if (searchTerm && searchTerm.trim() !== "") {
-    const escaped = escapeLikeWildcards(searchTerm.trim());
-    const term = `%${escaped}%`;
-    // Usar filtros separados con .or() requiere comillas alrededor de cada valor
-    query = query.or(`nombre.ilike."${term}",nacionalidad.ilike."${term}"`);
+    query = query.or(buildOrILikeFilter(["nombre", "nacionalidad"], searchTerm));
   }
 
   const { data, error, count } = await query;
@@ -171,8 +161,8 @@ export async function checkAuthorExists(
 ): Promise<boolean> {
   const adminClient = createAdminClient();
 
-  const escapedNombre = escapeLikeWildcards(nombre.trim());
-  const escapedNacionalidad = escapeLikeWildcards(nacionalidad.trim());
+  const escapedNombre = escapeLikePattern(nombre.trim());
+  const escapedNacionalidad = escapeLikePattern(nacionalidad.trim());
 
   let query = adminClient
     .from("autor")

--- a/biblioteca-alejandria/models/categoryModel.ts
+++ b/biblioteca-alejandria/models/categoryModel.ts
@@ -58,7 +58,8 @@ export async function createCategory(
  */
 export async function getCategories(
   page: number = 1,
-  pageSize: number = 10
+  pageSize: number = 10,
+  searchTerm?: string
 ): Promise<Paginated<CategoryWithBookCount>> {
   const adminClient = createAdminClient();
 
@@ -67,12 +68,19 @@ export async function getCategories(
   const from = (safePage - 1) * safePageSize;
   const to = from + safePageSize - 1;
 
-  const { data, error, count } = await adminClient
+  let query = adminClient
     .from("categoria")
     .select("*, libro(count)", { count: "exact" })
     .is("deleted_at", null)
     .range(from, to)
     .order("id", { ascending: false });
+
+  if (searchTerm && searchTerm.trim() !== "") {
+    const normalizedSearch = formatILIKE(searchTerm);
+    query = query.ilike("nombre", normalizedSearch);
+  }
+
+  const { data, error, count } = await query;
 
   if (error) throw error;
 
@@ -87,35 +95,6 @@ export async function getCategories(
     pageSize: safePageSize,
     totalPages: Math.ceil((count || 0) / safePageSize),
   };
-}
-
-/**
- * Busca categorías activas por coincidencia parcial de nombre.
- */
-export async function searchCategoriesByName(
-  searchTerm: string,
-  limit: number = 20
-): Promise<CategoryWithBookCount[]> {
-  const adminClient = createAdminClient();
-  const normalizedSearch = formatILIKE(searchTerm);
-  const safeLimit = Math.max(1, limit);
-
-  const { data, error } = await adminClient
-    .from("categoria")
-    .select("*, libro(count)")
-    .is("deleted_at", null)
-    .ilike("nombre", normalizedSearch)
-    .order("nombre", { ascending: true })
-    .limit(safeLimit);
-
-  if (error) {
-    console.error("Error al buscar categorías por nombre:", error);
-    throw error;
-  }
-
-  return (data ?? []).map((row) =>
-    normalizeCategoryWithBookCount(row as CategoryRow & Record<string, unknown>)
-  );
 }
 
 /**

--- a/biblioteca-alejandria/services/admin/adminService.ts
+++ b/biblioteca-alejandria/services/admin/adminService.ts
@@ -1,10 +1,10 @@
-import { getAdminUsers, searchAdminUsers, getCurrentUser } from "@/models/authModel";
+import { getAdminUsers, getCurrentUser } from "@/models/authModel";
 import { requireRootRole } from "@/lib/validations/server-auth";
 import { registerAuthUser } from "@/services/auth/registrationService";
 import { logAdminAction } from "@/services/admin/auditService";
 import { AccionAdministrador } from "@/lib/types/audit";
 import { Rol } from "@/lib/types/auth";
-import type { AdminUsersResponse, AdminSearchResponse } from "@/lib/types/profile";
+import type { AdminUsersResponse } from "@/lib/types/profile";
 import type { CredentialData, RegisterResponse } from "@/lib/types/auth";
 
 // ─── Helpers ────────────────────────────────────────────────────────
@@ -98,7 +98,8 @@ export async function createAdminAccount(
  */
 export async function fetchAdminUsers(
   page: number = 1,
-  pageSize: number = 10
+  pageSize: number = 10,
+  searchTerm?: string
 ): Promise<AdminUsersResponse> {
   try {
     const roleCheck = await requireRootRole();
@@ -108,7 +109,7 @@ export async function fetchAdminUsers(
         ...roleCheck}
     };
 
-    const result = await getAdminUsers(page, pageSize);
+    const result = await getAdminUsers(page, pageSize, searchTerm);
     
     return {
       success: true,
@@ -126,49 +127,3 @@ export async function fetchAdminUsers(
   }
 }
 
-/**
- * Servicio para buscar usuarios administradores por correo, nombre o apellidos.
- * 
- * Orquesta la llamada al modelo y maneja posibles errores.
- * 
- * @param searchTerm - Término de búsqueda para filtrar administradores
- * @returns Respuesta con listado de usuarios administradores que coinciden con la búsqueda
- */
-export async function searchAdmins(
-  searchTerm: string
-): Promise<AdminSearchResponse> {
-  try {
-    const roleCheck = await requireRootRole();
-
-    if (!roleCheck.success) {
-      return {
-        ...roleCheck
-      };
-    }
-    
-    // Validación básica del término de búsqueda
-    if (!searchTerm || searchTerm.trim().length === 0) {
-      return {
-        success: false,
-        errors: { search: "El término de búsqueda no puede estar vacío." },
-        message: "Por favor ingresa un término de búsqueda válido.",
-      };
-    }
-
-    const result = await searchAdminUsers(searchTerm);
-    
-    return {
-      success: true,
-      data: result,
-    };
-  } catch (error: unknown) {
-    console.error("Error al buscar usuarios administradores:", error);
-    const errorMessage = error instanceof Error ? error.message : "Error desconocido";
-    
-    return {
-      success: false,
-      errors: { form: errorMessage },
-      message: "No se pudo realizar la búsqueda de administradores.",
-    };
-  }
-}

--- a/biblioteca-alejandria/services/categories/categoryService.ts
+++ b/biblioteca-alejandria/services/categories/categoryService.ts
@@ -5,21 +5,15 @@ import {
   getActiveCategoryByExactNameExcludingId,
   getActiveCategoryById,
   hasActiveBooksForCategory,
-  searchCategoriesByName as searchCategoriesByNameModel,
   softDeleteCategoryById,
   updateCategoryById,
 } from "@/models/categoryModel";
 import type {
   CategoryCreateInput,
-  CategoryWithBookCount,
   CategoryUpdateInput,
   CategoryListResponse,
-  CategorySearchResponse,
   CategoryActionResponse,
 } from "@/lib/types/category";
-import type {
-  DataResponse,
-} from "@/lib/types/common";
 import { requireAdminRole } from "@/lib/validations/server-auth";
 import { sanitizeNullableText, sanitizeText } from "@/lib/validations/rules";
 
@@ -46,12 +40,18 @@ function isSameName(left: string, right: string): boolean {
 export async function fetchCategories(
   page: number = 1,
   pageSize: number = 10,
+  searchTerm?: string,
 ): Promise<CategoryListResponse> {
   try {
     const roleCheck = await requireAdminRole();
     if (!roleCheck.success) return roleCheck;
 
-    const data = await getCategoriesModel(page, pageSize);
+    const normalizedSearch = searchTerm ? normalizeCategoryName(searchTerm) : "";
+    const data = await getCategoriesModel(
+      page,
+      pageSize,
+      normalizedSearch || undefined,
+    );
     return {
       success: true,
       data,
@@ -265,39 +265,3 @@ export async function deleteCategory(
   }
 }
 
-/**
- * Busca categorías activas por nombre.
- */
-export async function searchCategoriesByName(
-  searchTerm: string,
-  limit: number = 20,
-): Promise<CategorySearchResponse> {
-  const roleCheck = await requireAdminRole();
-  if (!roleCheck.success) return roleCheck;
-
-  try {
-    const normalizedSearchTerm = normalizeCategoryName(searchTerm ?? "");
-    if (!normalizedSearchTerm) {
-      return {
-        success: false,
-        errors: { search: "El término de búsqueda no puede estar vacío." },
-        message: "Por favor ingresa un término de búsqueda válido.",
-      };
-    }
-
-    const data = await searchCategoriesByNameModel(normalizedSearchTerm, limit);
-    return {
-      success: true,
-      data,
-    };
-  } catch (error: unknown) {
-    console.error("Error inesperado al buscar categorías:", error);
-    const errorMessage =
-      error instanceof Error ? error.message : "Error desconocido";
-    return {
-      success: false,
-      errors: { form: errorMessage },
-      message: "No se pudo realizar la búsqueda de categorías.",
-    };
-  }
-}


### PR DESCRIPTION
…cteres especiales y espacios

Cambios principales:

 1. REFACTOR BÚSQUEDAS - Patrón oro unificado (listado + búsqueda paginados)
    - models/authModel.ts: getAdminUsers() ahora acepta searchTerm?
    - models/categoryModel.ts: getCategories() ahora acepta searchTerm?
    - models/authorModel.ts: getAuthors() ahora acepta searchTerm?
    - Eliminadas funciones de búsqueda aisladas: searchAdminUsers, searchCategoriesByName
    - Eliminadas respuestas de búsqueda aisladas: AdminSearchResponse, CategorySearchResponse

 2. REORGANIZACIÓN SERVICIOS
    - Movido services/categoryService.ts → services/categories/categoryService.ts
    - Actualizado fetchCategories() para aceptar searchTerm?
    - Eliminada searchCategoriesByName() del servicio
    - Actualizado fetchAdminUsers() para aceptar searchTerm?
    - Eliminado searchAdmins() del servicio

 3. SERVER ACTIONS SIMPLIFICADAS
    - panel-root/administradores/action.ts: getAdminUsers() → getAdminUsersAction(page, limit, term?)
    - panel-admin/categorias/action.ts: getCategoriesAction() ahora acepta searchTerm?
    - Eliminadas searchAdminsByTerm(), searchCategoriesAction()

 4. FRONTEND SIMPLIFICADO
    - AdministradoresContent.tsx: Una única función loadAdmins(page, term) reutilizada en useEffect y refresh
    - CategoriasContent.tsx: Una única función loadCategories(page, term) reutilizada en useEffect y refresh
    - AutoresContent.tsx: Ya soportaba patrón unificado, sin cambios adicionales
    - Eliminada lógica de búsqueda duplicada y refreshes separados

 5. BLINDAJE DE BÚSQUEDAS - Protección contra inyección + espacios variables
    - lib/validations/db-utils.ts: * quotePostgrestFilterValue(): Escapa comillas y backslash para literales PostgREST * buildOrILikeFilter(columns[], term): Construye filtros OR seguros para ILIKE multi-columna * formatILIKE(): Ahora convierte espacios internos a wildcards (ff ggg → %ff%ggg%) para tolerar espaciado variable
    - models/authModel.ts: getAdminUsers() usa buildOrILikeFilter() en .or()
    - models/authorModel.ts: getAuthors() usa buildOrILikeFilter() en .or()
    - Manejo robusto de caracteres especiales: , comillas dobles % _ \ sin errores PGRST100/22P02