### PR TITLE
migration: refactor noticias histórico

### DIFF
--- a/biblioteca-alejandria/lib/types/supabase.ts
+++ b/biblioteca-alejandria/lib/types/supabase.ts
@@ -39,15 +39,7 @@ export type Database = {
           id?: number
           id_usuario?: string | null
         }
-        Relationships: [
-          {
-            foreignKeyName: "Auditoria_id_usuario_fkey"
-            columns: ["id_usuario"]
-            isOneToOne: false
-            referencedRelation: "usuario"
-            referencedColumns: ["id"]
-          },
-        ]
+        Relationships: []
       }
       autor: {
         Row: {
@@ -548,23 +540,26 @@ export type Database = {
         Row: {
           deleted_at: string | null
           es_visible: boolean
+          fecha_expiracion: string
           fecha_publicacion: string
           id: string
-          id_libro: string | null
+          id_libro: string
         }
         Insert: {
           deleted_at?: string | null
           es_visible: boolean
+          fecha_expiracion?: string
           fecha_publicacion: string
           id?: string
-          id_libro?: string | null
+          id_libro: string
         }
         Update: {
           deleted_at?: string | null
           es_visible?: boolean
+          fecha_expiracion?: string
           fecha_publicacion?: string
           id?: string
-          id_libro?: string | null
+          id_libro?: string
         }
         Relationships: [
           {

--- a/biblioteca-alejandria/supabase/migrations/20260420000000_refactor_noticias_historico.sql
+++ b/biblioteca-alejandria/supabase/migrations/20260420000000_refactor_noticias_historico.sql
@@ -1,0 +1,27 @@
+-- Migración: Refactorización tipos
+-- Objetivo: Preparar DB para refactor de noticias e logs histórico.
+
+-- 1. Tabla: historico
+-- Modificar 'fecha' a TIMESTAMPTZ para incluir hora exacta del log
+ALTER TABLE public.historico
+ALTER COLUMN fecha TYPE TIMESTAMPTZ USING fecha::TIMESTAMPTZ;
+
+-- 2. Tabla: noticias
+-- 2.1 Opcional: limpiar nulos si la consola falla al aplicar NOT NULL
+-- DELETE FROM public.noticias WHERE id_libro IS NULL;
+
+-- 2.2 Forzar id_libro a ser NOT NULL (noticia siempre ligada a un libro)
+ALTER TABLE public.noticias
+ALTER COLUMN id_libro SET NOT NULL;
+
+-- 2.3 Agregar campo fecha_expiracion, default 8 días desde que se aplica
+ALTER TABLE public.noticias
+ADD COLUMN IF NOT EXISTS fecha_expiracion TIMESTAMPTZ NOT NULL DEFAULT (now() + interval '8 days');
+
+-- 2.4 Reemplazar FK para permitir ON DELETE CASCADE (aplica a borrados físicos)
+ALTER TABLE public.noticias
+DROP CONSTRAINT IF EXISTS noticias_id_libro_fkey;
+
+ALTER TABLE public.noticias
+ADD CONSTRAINT noticias_id_libro_fkey 
+FOREIGN KEY (id_libro) REFERENCES public.libro(id) ON DELETE CASCADE;


### PR DESCRIPTION
se modifican las tablas historico y noticia.
Para historico se cambia el tipo de la columna 'fecha' de DATE  a TIMESTAMPTZ para guardar también la hora de cambio. Para la tabla noticia se agrega la columna fecha_expiracion con un valor por defecto del momento actual + 8 días. Se manejará dependencia total con libro, por lo que este valor no puede ser nulo. Para integridad se agrega el constraint de borrado en cascada para borrado físico. Se debe tener en cuenta borrado lógico de noticia al realizar borrado lógico de libro.