### PR TITLE
feat: modelos copia, historico y noticia

### DIFF
--- a/biblioteca-alejandria/lib/types/noticia.ts
+++ b/biblioteca-alejandria/lib/types/noticia.ts
@@ -11,15 +11,16 @@ export type NoticiaRow = Database["public"]["Tables"]["noticias"]["Row"];
 /** Payload para crear una nueva noticia. */
 export interface InsertNoticiaPayload {
   fecha_publicacion: string;
+  fecha_expiracion?: string;
   es_visible: boolean;
-  id_libro?: string | null;
+  id_libro: string;
 }
 
 /** Payload para actualizar una noticia existente. */
 export interface UpdateNoticiaPayload {
   fecha_publicacion?: string;
+  fecha_expiracion?: string;
   es_visible?: boolean;
-  id_libro?: string | null;
 }
 
 // ─── Tipos con datos derivados ─────────────────────────────────────

--- a/biblioteca-alejandria/models/copiaModel.ts
+++ b/biblioteca-alejandria/models/copiaModel.ts
@@ -108,7 +108,7 @@ export async function getCopias(
     .select("*", { count: "exact" })
     .is("deleted_at", null)
     .range(from, to)
-    .order("created_at", { ascending: false });
+    .order("id", { ascending: false });
 
   if (id_tienda) {
     query = query.eq("id_tienda", id_tienda);

--- a/biblioteca-alejandria/models/copiaModel.ts
+++ b/biblioteca-alejandria/models/copiaModel.ts
@@ -1,0 +1,156 @@
+import { createAdminClient } from "@/lib/supabase/server";
+import type { ModelResult, Paginated } from "@/lib/types/common";
+import type {
+  CopiaRow,
+  InsertCopiaPayload,
+  UpdateCopiaPayload,
+} from "@/lib/types/copia";
+import { MAX_PAGE_SIZE } from "@/lib/validations/rules";
+
+// ─── Escritura ─────────────────────────────────────────────────────
+
+export async function insertCopia(
+  data: InsertCopiaPayload
+): Promise<ModelResult> {
+  const adminClient = createAdminClient();
+
+  const { error } = await adminClient.from("copia").insert({
+    id_libro: data.id_libro,
+    id_tienda: data.id_tienda,
+    estado: data.estado,
+  });
+
+  if (error) {
+    console.error("[copiaModel] Error insertando copia:", error);
+    return { success: false, error: error.message };
+  }
+
+  return { success: true };
+}
+
+export async function updateCopia(
+  id: string,
+  data: UpdateCopiaPayload
+): Promise<ModelResult> {
+  const adminClient = createAdminClient();
+
+  const { error } = await adminClient
+    .from("copia")
+    .update({
+      estado: data.estado,
+      id_tienda: data.id_tienda,
+    })
+    .eq("id", id)
+    .is("deleted_at", null);
+
+  if (error) {
+    console.error("[copiaModel] Error actualizando copia:", error);
+    return { success: false, error: error.message };
+  }
+
+  return { success: true };
+}
+
+export async function softDeleteCopia(id: string): Promise<ModelResult> {
+  const adminClient = createAdminClient();
+
+  const { error } = await adminClient
+    .from("copia")
+    .update({ deleted_at: new Date().toISOString() })
+    .eq("id", id)
+    .is("deleted_at", null);
+
+  if (error) {
+    console.error("[copiaModel] Error eliminando copia:", error);
+    return { success: false, error: error.message };
+  }
+
+  return { success: true };
+}
+
+// ─── Lectura ───────────────────────────────────────────────────────
+
+export async function getCopiaById(
+  id: string
+): Promise<CopiaRow | null> {
+  const adminClient = createAdminClient();
+
+  const { data, error } = await adminClient
+    .from("copia")
+    .select("*")
+    .eq("id", id)
+    .is("deleted_at", null)
+    .maybeSingle();
+
+  if (error) {
+    console.error("[copiaModel] Error obteniendo copia por id:", error);
+    throw error;
+  }
+
+  return data;
+}
+
+export async function getCopias(
+  page: number = 1,
+  pageSize: number = 10,
+  searchTerm?: string,
+  id_tienda?: string
+): Promise<Paginated<CopiaRow>> {
+  const adminClient = createAdminClient();
+
+  const safePage = Math.max(1, page);
+  const safePageSize = Math.min(Math.max(1, pageSize), MAX_PAGE_SIZE);
+  const from = (safePage - 1) * safePageSize;
+  const to = from + safePageSize - 1;
+
+  let query = adminClient
+    .from("copia")
+    .select("*", { count: "exact" })
+    .is("deleted_at", null)
+    .range(from, to)
+    .order("created_at", { ascending: false });
+
+  if (id_tienda) {
+    query = query.eq("id_tienda", id_tienda);
+  }
+
+  if (searchTerm && searchTerm.trim() !== "") {
+    // Si la tabla copia tiene uuid, busqueda por uuid exacto
+    // asumiendo uuid
+    query = query.eq("id", searchTerm.trim());
+  }
+
+  const { data, error, count } = await query;
+
+  if (error) {
+    console.error("[copiaModel] Error listando copias:", error);
+    throw error;
+  }
+
+  const totalCount = count || 0;
+
+  return {
+    data: data || [],
+    total: totalCount,
+    page: safePage,
+    pageSize: safePageSize,
+    totalPages: Math.ceil(totalCount / safePageSize),
+  };
+}
+
+export async function countCopiasByLibro(id_libro: string): Promise<number> {
+  const adminClient = createAdminClient();
+
+  const { count, error } = await adminClient
+    .from("copia")
+    .select("id", { count: "exact", head: true })
+    .eq("id_libro", id_libro)
+    .is("deleted_at", null);
+
+  if (error) {
+    console.error("[copiaModel] Error contando copias por libro:", error);
+    throw error;
+  }
+
+  return count ?? 0;
+}

--- a/biblioteca-alejandria/models/historicoModel.ts
+++ b/biblioteca-alejandria/models/historicoModel.ts
@@ -1,0 +1,65 @@
+import { createAdminClient } from "@/lib/supabase/server";
+import type { ModelResult, Paginated } from "@/lib/types/common";
+import type {
+  HistoricoRow,
+  InsertHistoricoPayload,
+} from "@/lib/types/historico";
+import { MAX_PAGE_SIZE } from "@/lib/validations/rules";
+
+// ─── Escritura ─────────────────────────────────────────────────────
+
+export async function insertHistorico(
+  data: InsertHistoricoPayload
+): Promise<ModelResult> {
+  const adminClient = createAdminClient();
+
+  const { error } = await adminClient.from("historico").insert({
+    id_libro: data.id_libro,
+    estado: data.estado,
+    fecha: data.fecha,
+  });
+
+  if (error) {
+    console.error("[historicoModel] Error insertando histórico:", error);
+    return { success: false, error: error.message };
+  }
+
+  return { success: true };
+}
+
+// ─── Lectura ───────────────────────────────────────────────────────
+
+export async function getHistoricoByLibro(
+  id_libro: string,
+  page: number = 1,
+  pageSize: number = 10
+): Promise<Paginated<HistoricoRow>> {
+  const adminClient = createAdminClient();
+
+  const safePage = Math.max(1, page);
+  const safePageSize = Math.min(Math.max(1, pageSize), MAX_PAGE_SIZE);
+  const from = (safePage - 1) * safePageSize;
+  const to = from + safePageSize - 1;
+
+  const { data, error, count } = await adminClient
+    .from("historico")
+    .select("*", { count: "exact" })
+    .eq("id_libro", id_libro)
+    .range(from, to)
+    .order("fecha", { ascending: false });
+
+  if (error) {
+    console.error("[historicoModel] Error listando logs histórico por libro:", error);
+    throw error;
+  }
+
+  const totalCount = count || 0;
+
+  return {
+    data: data || [],
+    total: totalCount,
+    page: safePage,
+    pageSize: safePageSize,
+    totalPages: Math.ceil(totalCount / safePageSize),
+  };
+}

--- a/biblioteca-alejandria/models/noticiaModel.ts
+++ b/biblioteca-alejandria/models/noticiaModel.ts
@@ -7,7 +7,7 @@ import type {
   NoticiaRow,
 } from "@/lib/types/noticia";
 import { MAX_PAGE_SIZE } from "@/lib/validations/rules";
-import { escapeLikePattern } from "@/lib/validations/db-utils";
+import { formatILIKE } from "@/lib/validations/db-utils";
 
 // ─── Escritura ─────────────────────────────────────────────────────
 
@@ -134,8 +134,7 @@ export async function getNoticias(
     .order("fecha_publicacion", { ascending: false });
 
   if (searchTerm && searchTerm.trim() !== "") {
-    const escapedSearch = escapeLikePattern(searchTerm.trim());
-    query = query.ilike("libro.titulo", `%${escapedSearch}%`);
+    query = query.ilike("libro.titulo", formatILIKE(searchTerm));
   }
 
   const { data, error, count } = await query;

--- a/biblioteca-alejandria/models/noticiaModel.ts
+++ b/biblioteca-alejandria/models/noticiaModel.ts
@@ -1,0 +1,167 @@
+import { createAdminClient } from "@/lib/supabase/server";
+import type { ModelResult, Paginated } from "@/lib/types/common";
+import type {
+  NoticiaWithLibro,
+  InsertNoticiaPayload,
+  UpdateNoticiaPayload,
+  NoticiaRow,
+} from "@/lib/types/noticia";
+import { MAX_PAGE_SIZE } from "@/lib/validations/rules";
+import { escapeLikePattern } from "@/lib/validations/db-utils";
+
+// ─── Escritura ─────────────────────────────────────────────────────
+
+export async function insertNoticia(
+  data: InsertNoticiaPayload
+): Promise<ModelResult> {
+  const adminClient = createAdminClient();
+
+  const { error } = await adminClient.from("noticias").insert({
+    id_libro: data.id_libro,
+    fecha_publicacion: data.fecha_publicacion,
+    fecha_expiracion: data.fecha_expiracion,
+    es_visible: data.es_visible,
+  });
+
+  if (error) {
+    console.error("[noticiaModel] Error insertando noticia:", error);
+    return { success: false, error: error.message };
+  }
+
+  return { success: true };
+}
+
+export async function updateNoticia(
+  id: string,
+  data: UpdateNoticiaPayload
+): Promise<ModelResult> {
+  const adminClient = createAdminClient();
+
+  const { error } = await adminClient
+    .from("noticias")
+    .update({
+      fecha_publicacion: data.fecha_publicacion,
+      fecha_expiracion: data.fecha_expiracion,
+      es_visible: data.es_visible,
+    })
+    .eq("id", id)
+    .is("deleted_at", null);
+
+  if (error) {
+    console.error("[noticiaModel] Error actualizando noticia:", error);
+    return { success: false, error: error.message };
+  }
+
+  return { success: true };
+}
+
+export async function softDeleteNoticia(id: string): Promise<ModelResult> {
+  const adminClient = createAdminClient();
+
+  const { error } = await adminClient
+    .from("noticias")
+    .update({ deleted_at: new Date().toISOString() })
+    .eq("id", id)
+    .is("deleted_at", null);
+
+  if (error) {
+    console.error("[noticiaModel] Error eliminando noticia:", error);
+    return { success: false, error: error.message };
+  }
+
+  return { success: true };
+}
+
+// ─── Lectura ───────────────────────────────────────────────────────
+
+export async function getNoticiaById(
+  id: string
+): Promise<NoticiaRow | null> {
+  const adminClient = createAdminClient();
+
+  const { data, error } = await adminClient
+    .from("noticias")
+    .select("*")
+    .eq("id", id)
+    .is("deleted_at", null)
+    .maybeSingle();
+
+  if (error) {
+    console.error("[noticiaModel] Error obteniendo noticia por id:", error);
+    throw error;
+  }
+
+  return data;
+}
+
+export async function getNoticiaByLibroId(
+  libroId: string
+): Promise<NoticiaRow | null> {
+  const adminClient = createAdminClient();
+
+  const { data, error } = await adminClient
+    .from("noticias")
+    .select("*")
+    .eq("id_libro", libroId)
+    .is("deleted_at", null)
+    .maybeSingle();
+
+  if (error) {
+    console.error("[noticiaModel] Error obteniendo noticia por id_libro:", error);
+    throw error;
+  }
+
+  return data;
+}
+
+export async function getNoticias(
+  page: number = 1,
+  pageSize: number = 10,
+  searchTerm?: string
+): Promise<Paginated<NoticiaWithLibro>> {
+  const adminClient = createAdminClient();
+
+  const safePage = Math.max(1, page);
+  const safePageSize = Math.min(Math.max(1, pageSize), MAX_PAGE_SIZE);
+  const from = (safePage - 1) * safePageSize;
+  const to = from + safePageSize - 1;
+
+  let query = adminClient
+    .from("noticias")
+    .select("*, libro!inner(titulo)", { count: "exact" })
+    .is("deleted_at", null)
+    .range(from, to)
+    .order("fecha_publicacion", { ascending: false });
+
+  if (searchTerm && searchTerm.trim() !== "") {
+    const escapedSearch = escapeLikePattern(searchTerm.trim());
+    query = query.ilike("libro.titulo", `%${escapedSearch}%`);
+  }
+
+  const { data, error, count } = await query;
+
+  if (error) {
+    console.error("[noticiaModel] Error listando noticias:", error);
+    throw error;
+  }
+
+  const normalized: NoticiaWithLibro[] = (data || []).map((row: any) => ({
+    id: row.id,
+    id_libro: row.id_libro,
+    fecha_publicacion: row.fecha_publicacion,
+    fecha_expiracion: row.fecha_expiracion,
+    es_visible: row.es_visible,
+    deleted_at: row.deleted_at,
+    libro_titulo: row.libro?.titulo || null,
+  }));
+
+  const totalCount = count || 0;
+
+  return {
+    data: normalized,
+    total: totalCount,
+    page: safePage,
+    pageSize: safePageSize,
+    totalPages: Math.ceil(totalCount / safePageSize),
+  };
+}


### PR DESCRIPTION
Implementados models con dependencias de libro. Crear copiaModel con funciones de conteo y filtrado por tienda Crear noticiaModel con soporte de visibilidad y busqueda por titulo de libro Crear historicoModel para registro de logs de estado en modo append-only Refactorizar tipos en noticia e historico para incluir fecha_expiracion y timestamps Incluir migracion sql para adaptar esquemas de base de datos