### PR TITLE
fix: hacer opcional nacionalidad y fecha_nacimiento en autores

### DIFF
--- a/biblioteca-alejandria/app/(with-navbar)/(panel)/panel-admin/autores/AuthorFormModal.tsx
+++ b/biblioteca-alejandria/app/(with-navbar)/(panel)/panel-admin/autores/AuthorFormModal.tsx
@@ -143,7 +143,7 @@ export default function AuthorFormModal({
     }
   };
 
-  // CanSubmit: no hay errores de validación y los campos obligatorios están llenos
+  // CanSubmit: el nombre no está vacío y no hay errores de validación
   const canSubmit =
     values.nombre.trim() !== "" &&
     Object.keys(errors).length === 0;

--- a/biblioteca-alejandria/app/(with-navbar)/(panel)/panel-admin/autores/AuthorFormModal.tsx
+++ b/biblioteca-alejandria/app/(with-navbar)/(panel)/panel-admin/autores/AuthorFormModal.tsx
@@ -131,10 +131,6 @@ export default function AuthorFormModal({
           onSuccess(response.id);
         }, 1500);
       } else {
-        // Mapear errores de servidor al formulario
-        if (response.errors) {
-          setErrors((prev) => ({ ...prev, ...response.errors }));
-        }
         setAlertState(response);
       }
     } catch {
@@ -150,8 +146,6 @@ export default function AuthorFormModal({
   // CanSubmit: no hay errores de validación y los campos obligatorios están llenos
   const canSubmit =
     values.nombre.trim() !== "" &&
-    values.nacionalidad.trim() !== "" &&
-    values.fecha_nacimiento.trim() !== "" &&
     Object.keys(errors).length === 0;
 
   return (
@@ -188,7 +182,6 @@ export default function AuthorFormModal({
           onChange={(e) => handleChange("nacionalidad", e.target.value)}
           onBlur={() => handleBlur("nacionalidad")}
           error={errors.nacionalidad}
-          required
           disabled={isSubmitting}
         />
 
@@ -200,7 +193,6 @@ export default function AuthorFormModal({
           onChange={(e) => handleChange("fecha_nacimiento", e.target.value)}
           onBlur={() => handleBlur("fecha_nacimiento")}
           error={errors.fecha_nacimiento}
-          required
           disabled={isSubmitting}
         />
 

--- a/biblioteca-alejandria/app/(with-navbar)/(panel)/panel-admin/autores/AutoresTable.tsx
+++ b/biblioteca-alejandria/app/(with-navbar)/(panel)/panel-admin/autores/AutoresTable.tsx
@@ -31,7 +31,7 @@ const authorColumns: Column<AuthorWithBookCount>[] = [
               {nombre}
             </span>
             <span className="text-xs text-brand-secondary/70 lg:hidden">
-              {item.nacionalidad || "Sin nacionalidad"}
+              {item.nacionalidad || "Desconocido"}
             </span>
           </div>
         </div>
@@ -40,13 +40,13 @@ const authorColumns: Column<AuthorWithBookCount>[] = [
   },
   {
     header: "Nacionalidad",
-    render: (item) => item.nacionalidad || "Sin nacionalidad",
+    render: (item) => item.nacionalidad || "Desconocido",
     className: "hidden lg:table-cell",
   },
   {
     header: "Fecha de nacimiento",
     render: (item) => {
-      if (!item.fecha_nacimiento) return "Sin fecha";
+      if (!item.fecha_nacimiento) return "Desconocido";
       const date = new Date(item.fecha_nacimiento + "T00:00:00");
       return date.toLocaleDateString("es-ES", {
         year: "numeric",

--- a/biblioteca-alejandria/app/(with-navbar)/(panel)/panel-admin/autores/action.ts
+++ b/biblioteca-alejandria/app/(with-navbar)/(panel)/panel-admin/autores/action.ts
@@ -6,7 +6,7 @@ import {
   removeAuthor,
   fetchAuthors,
 } from "@/services/authors/authorService";
-import { sanitizeText } from "@/lib/validations/rules";
+import { sanitizeText, sanitizeNullableText } from "@/lib/validations/rules";
 import { validateAuthor } from "@/lib/validations/author";
 import type {
   AuthorsListResponse,
@@ -24,8 +24,8 @@ export async function crearAutor(
   fechaNacimiento: string
 ): Promise<AuthorActionResponse> {
   const cleanNombre = sanitizeText(nombre);
-  const cleanNacionalidad = nacionalidad.trim() || null;
-  const cleanFecha = fechaNacimiento.trim() || null;
+  const cleanNacionalidad = sanitizeNullableText(nacionalidad);
+  const cleanFecha = sanitizeNullableText(fechaNacimiento);
 
   const errors = validateAuthor({
     nombre: cleanNombre,
@@ -58,8 +58,8 @@ export async function actualizarAutor(
   }
 
   const cleanNombre = sanitizeText(nombre);
-  const cleanNacionalidad = nacionalidad.trim() || null;
-  const cleanFecha = fechaNacimiento.trim() || null;
+  const cleanNacionalidad = sanitizeNullableText(nacionalidad);
+  const cleanFecha = sanitizeNullableText(fechaNacimiento);
 
   const errors = validateAuthor({
     nombre: cleanNombre,

--- a/biblioteca-alejandria/app/(with-navbar)/(panel)/panel-admin/autores/action.ts
+++ b/biblioteca-alejandria/app/(with-navbar)/(panel)/panel-admin/autores/action.ts
@@ -24,8 +24,8 @@ export async function crearAutor(
   fechaNacimiento: string
 ): Promise<AuthorActionResponse> {
   const cleanNombre = sanitizeText(nombre);
-  const cleanNacionalidad = sanitizeText(nacionalidad);
-  const cleanFecha = fechaNacimiento.trim();
+  const cleanNacionalidad = nacionalidad.trim() || null;
+  const cleanFecha = fechaNacimiento.trim() || null;
 
   const errors = validateAuthor({
     nombre: cleanNombre,
@@ -58,8 +58,8 @@ export async function actualizarAutor(
   }
 
   const cleanNombre = sanitizeText(nombre);
-  const cleanNacionalidad = sanitizeText(nacionalidad);
-  const cleanFecha = fechaNacimiento.trim();
+  const cleanNacionalidad = nacionalidad.trim() || null;
+  const cleanFecha = fechaNacimiento.trim() || null;
 
   const errors = validateAuthor({
     nombre: cleanNombre,

--- a/biblioteca-alejandria/lib/types/author.ts
+++ b/biblioteca-alejandria/lib/types/author.ts
@@ -18,15 +18,15 @@ export interface AuthorWithBookCount extends AuthorRow {
 /** Payload para crear un nuevo autor. */
 export interface InsertAuthorPayload {
   nombre: string;
-  nacionalidad: string;
-  fecha_nacimiento: string;
+  nacionalidad: string | null;
+  fecha_nacimiento: string | null;
 }
 
 /** Payload para actualizar un autor existente. */
 export interface UpdateAuthorPayload {
   nombre: string;
-  nacionalidad: string;
-  fecha_nacimiento: string;
+  nacionalidad: string | null;
+  fecha_nacimiento: string | null;
 }
 
 // ─── Valores del formulario (frontend) ─────────────────────────────

--- a/biblioteca-alejandria/lib/validations/author.ts
+++ b/biblioteca-alejandria/lib/validations/author.ts
@@ -6,8 +6,8 @@ import {
 
 export interface AuthorValidationPayload {
   nombre: string;
-  nacionalidad: string;
-  fecha_nacimiento: string;
+  nacionalidad: string | null;
+  fecha_nacimiento: string | null;
 }
 
 // Fecha mínima razonable: autores históricos más remotos (~700 años A.D.)
@@ -27,19 +27,11 @@ export function validateAuthor(payload: AuthorValidationPayload): Record<string,
   if (nombreError) errors.nombre = nombreError;
 
   const nacionalidadError = validateFieldRules(payload.nacionalidad, [
-    requiredRule("Nacionalidad"),
     maxLengthRule(100, "Nacionalidad"),
   ]);
   if (nacionalidadError) errors.nacionalidad = nacionalidadError;
 
-  // Validación de fecha: requerida + formato + rango histórico-razonable
-  const fechaReq = validateFieldRules(payload.fecha_nacimiento, [
-    requiredRule("Fecha de nacimiento"),
-  ]);
-
-  if (fechaReq) {
-    errors.fecha_nacimiento = fechaReq;
-  } else {
+  if (payload.fecha_nacimiento) {
     const date = new Date(payload.fecha_nacimiento);
 
     if (isNaN(date.getTime())) {

--- a/biblioteca-alejandria/lib/validations/author.ts
+++ b/biblioteca-alejandria/lib/validations/author.ts
@@ -6,8 +6,8 @@ import {
 
 export interface AuthorValidationPayload {
   nombre: string;
-  nacionalidad: string | null;
-  fecha_nacimiento: string | null;
+  nacionalidad?: string | null;
+  fecha_nacimiento?: string | null;
 }
 
 // Fecha mínima razonable: autores históricos más remotos (~700 años A.D.)

--- a/biblioteca-alejandria/models/authorModel.ts
+++ b/biblioteca-alejandria/models/authorModel.ts
@@ -157,20 +157,24 @@ export async function getAuthors(
  */
 export async function checkAuthorExists(
   nombre: string,
-  nacionalidad: string,
+  nacionalidad: string | null,
   excludeId?: number
 ): Promise<boolean> {
   const adminClient = createAdminClient();
 
   const escapedNombre = escapeLikePattern(nombre.trim());
-  const escapedNacionalidad = escapeLikePattern(nacionalidad.trim());
+  const hasNacionalidad = nacionalidad && nacionalidad.trim() !== "";
 
   let query = adminClient
     .from("autor")
     .select("id")
     .ilike("nombre", escapedNombre)
-    .ilike("nacionalidad", escapedNacionalidad)
     .is("deleted_at", null);
+
+  if (hasNacionalidad) {
+    const escapedNacionalidad = escapeLikePattern(nacionalidad!.trim());
+    query = query.ilike("nacionalidad", escapedNacionalidad);
+  }
 
   if (excludeId !== undefined) {
     query = query.neq("id", excludeId);

--- a/biblioteca-alejandria/models/authorModel.ts
+++ b/biblioteca-alejandria/models/authorModel.ts
@@ -163,7 +163,7 @@ export async function checkAuthorExists(
   const adminClient = createAdminClient();
 
   const escapedNombre = escapeLikePattern(nombre.trim());
-  const hasNacionalidad = nacionalidad && nacionalidad.trim() !== "";
+  const hasNacionalidad = !!(nacionalidad && nacionalidad.trim() !== "");
 
   let query = adminClient
     .from("autor")
@@ -174,13 +174,15 @@ export async function checkAuthorExists(
   if (hasNacionalidad) {
     const escapedNacionalidad = escapeLikePattern(nacionalidad!.trim());
     query = query.ilike("nacionalidad", escapedNacionalidad);
+  } else {
+    query = query.is("nacionalidad", null);
   }
 
   if (excludeId !== undefined) {
     query = query.neq("id", excludeId);
   }
 
-  const { data, error } = await query.maybeSingle();
+  const { data, error } = await query.limit(1).maybeSingle();
 
   if (error) {
     console.error("[authorModel] Error al verificar existencia de autor:", error);

--- a/biblioteca-alejandria/models/noticiaModel.ts
+++ b/biblioteca-alejandria/models/noticiaModel.ts
@@ -20,6 +20,7 @@ interface NoticiaBaseRow {
   fecha_expiracion: string;
   es_visible: boolean;
   deleted_at: string | null;
+  imagenes: string[] | null;
 }
 
 interface NoticiaConLibroTitulo extends NoticiaBaseRow {
@@ -39,6 +40,7 @@ function mapNoticiaBase(row: NoticiaBaseRow) {
     fecha_expiracion: row.fecha_expiracion,
     es_visible: row.es_visible,
     deleted_at: row.deleted_at,
+    imagenes: row.imagenes,
   };
 }
 

--- a/biblioteca-alejandria/models/tiendaModel.ts
+++ b/biblioteca-alejandria/models/tiendaModel.ts
@@ -22,7 +22,7 @@ type TiendaListRow = TiendaRow & {
   > | null;
 };
 
-const TIENDA_BASE_COLUMNS = "id, nombre, horario, id_direccion, deleted_at";
+const TIENDA_BASE_COLUMNS = "id, nombre, horario, id_direccion, es_bodega, deleted_at";
 
 function normalizeTiendaRow(row: TiendaRow): TiendaRead {
   return {
@@ -30,6 +30,7 @@ function normalizeTiendaRow(row: TiendaRow): TiendaRead {
     nombre: row.nombre,
     horario: row.horario as unknown as TiendaRead["horario"],
     id_direccion: row.id_direccion,
+    es_bodega: row.es_bodega,
     deleted_at: row.deleted_at,
   };
 }

--- a/biblioteca-alejandria/services/authors/authorService.ts
+++ b/biblioteca-alejandria/services/authors/authorService.ts
@@ -37,7 +37,7 @@ export async function createAuthor(
     if (exists) {
       return {
         success: false,
-        errors: { nombre: "Ya existe un autor con este nombre y nacionalidad." },
+        errors: { nombre: "Ya existe un autor con este nombre." },
         message: "El autor ya está registrado.",
       };
     }
@@ -62,7 +62,7 @@ export async function createAuthor(
     await logAdminAction({
       actorId: actor.id,
       action: AccionAdministrador.CREAR,
-      description: `Se creó el autor "${data.nombre}" (${data.nacionalidad}).`,
+      description: `Se creó el autor "${data.nombre}"${data.nacionalidad ? ` (${data.nacionalidad})` : ""}.`,
       entity: { id: "desconocido", entity_type: "autor", display_name: data.nombre },
     });
   }
@@ -89,7 +89,7 @@ export async function editAuthor(
     if (exists) {
       return {
         success: false,
-        errors: { nombre: "Ya existe otro autor con este nombre y nacionalidad." },
+        errors: { nombre: "Ya existe otro autor con este nombre." },
         message: "El autor ya está registrado.",
       };
     }


### PR DESCRIPTION
- Validación: nacionalidad y fecha_nacimiento ya no son requeridos
- Formulario: removido atributo required de ambos campos
- action.ts: convertir strings vacíos a null para BD
- checkAuthorExists: handle null en nacionalidad
- UI: mostrar 'Desconocido' cuando null en vez de 'Sin nacionalidad'/'Sin fecha'
- UX: errores del servidor solo en Alert, no en inputs del formulario