### PR TITLE
refactor(ui): convert Alert to portal-based toast overlay system

### DIFF
--- a/biblioteca-alejandria/app/(auth)/login/LoginForm.tsx
+++ b/biblioteca-alejandria/app/(auth)/login/LoginForm.tsx
@@ -97,7 +97,7 @@ export default function LoginForm() {
 
       {/* Mensaje de error global */}
       {error && (
-        <Alert variant="error" className="top-1">
+        <Alert variant="error">
           {error}
         </Alert>
       )}

--- a/biblioteca-alejandria/app/(auth)/password-recovery/PasswordRecoveryForm.tsx
+++ b/biblioteca-alejandria/app/(auth)/password-recovery/PasswordRecoveryForm.tsx
@@ -315,9 +315,9 @@ export default function PasswordRecoveryForm() {
 
       {/* Mensajes de error/éxito */}
       {error ? (
-        <Alert variant="error" className="top-1">{error}</Alert>
+        <Alert variant="error">{error}</Alert>
       ) : successMessage && currentStep < 3 ? (
-        <Alert variant="success" className="top-1">{successMessage}</Alert>
+        <Alert variant="success">{successMessage}</Alert>
       ) : null}
 
       {/* ─── Step 1: Email ─── */}

--- a/biblioteca-alejandria/app/(auth)/register/RegistroForm.tsx
+++ b/biblioteca-alejandria/app/(auth)/register/RegistroForm.tsx
@@ -235,7 +235,7 @@ export default function RegistroForm() {
             )}
 
             {success && (
-                <Alert variant="success" className="absolute left-1/2 -translate-x-1/2 z-50">
+                <Alert variant="success">
                     Registro exitoso. ¡Bienvenido!
                 </Alert>
             )}

--- a/biblioteca-alejandria/app/(with-navbar)/(panel)/panel-admin/autores/AutoresContent.tsx
+++ b/biblioteca-alejandria/app/(with-navbar)/(panel)/panel-admin/autores/AutoresContent.tsx
@@ -3,7 +3,7 @@
 import Button from "@/components/ui/Button";
 import FilterActionBar from "@/components/ui/FilterActionBar";
 import Alert from "@/components/ui/Alert";
-import { Plus, Loader2, AlertCircle, CheckCircle } from "lucide-react";
+import { Plus, Loader2 } from "lucide-react";
 import { useState, useEffect } from "react";
 import { obtenerAutores, eliminarAutor } from "./action";
 import type { AuthorWithBookCount } from "@/lib/types/author";
@@ -135,8 +135,7 @@ export default function AutoresContent() {
     <main className="flex-1 w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10 md:py-12 relative">
       {/* Alerts */}
       {errorLoading && (
-        <Alert variant="error" className="mb-6 flex items-center gap-2">
-          <AlertCircle className="w-4 h-4" />
+        <Alert variant="error">
           {errorLoading}
         </Alert>
       )}
@@ -144,10 +143,8 @@ export default function AutoresContent() {
       {actionResponse?.success === true && (
         <Alert
           variant="success"
-          className="mb-6 flex items-center gap-2"
           onClose={() => setActionResponse(null)}
         >
-          <CheckCircle className="w-4 h-4" />
           {actionResponse.message || "Operación completada exitosamente"}
         </Alert>
       )}
@@ -155,10 +152,8 @@ export default function AutoresContent() {
       {actionResponse?.success === false && (
         <Alert
           variant="error"
-          className="mb-6 flex items-center gap-2"
           onClose={() => setActionResponse(null)}
         >
-          <AlertCircle className="w-4 h-4" />
           {actionResponse.message || "Error al procesar la operación"}
         </Alert>
       )}

--- a/biblioteca-alejandria/app/(with-navbar)/(panel)/panel-admin/categorias/CategoriasContent.tsx
+++ b/biblioteca-alejandria/app/(with-navbar)/(panel)/panel-admin/categorias/CategoriasContent.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import Button from "@/components/ui/Button";
 import FilterActionBar from "@/components/ui/FilterActionBar";
 import Alert from "@/components/ui/Alert";
-import { AlertCircle, CheckCircle, Loader2, Plus } from "lucide-react";
+import { Loader2, Plus } from "lucide-react";
 import { useDebounce } from "@/hooks/useDebounce";
 import type {
   CategoryActionResponse,
@@ -130,11 +130,7 @@ export default function CategoriasContent() {
   return (
     <main className="flex-1 w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10 md:py-12 relative">
       {errorLoadingCategorias && (
-        <Alert
-          variant="error"
-          className="mb-6 flex items-center gap-2 !relative !left-0 !translate-x-0"
-        >
-          <AlertCircle className="w-4 h-4" />
+        <Alert variant="error">
           {errorLoadingCategorias}
         </Alert>
       )}
@@ -142,10 +138,8 @@ export default function CategoriasContent() {
       {actionResponse?.success && actionResponse.message && (
         <Alert
           variant="success"
-          className="mb-6 flex items-center gap-2 !relative !left-0 !translate-x-0"
           onClose={() => setActionResponse(null)}
         >
-          <CheckCircle className="w-4 h-4" />
           {actionResponse.message}
         </Alert>
       )}
@@ -153,10 +147,8 @@ export default function CategoriasContent() {
       {!actionResponse?.success && actionResponse?.message && (
         <Alert
           variant="error"
-          className="mb-6 flex items-center gap-2 !relative !left-0 !translate-x-0"
           onClose={() => setActionResponse(null)}
         >
-          <AlertCircle className="w-4 h-4" />
           {actionResponse.message}
         </Alert>
       )}

--- a/biblioteca-alejandria/app/(with-navbar)/(panel)/panel-admin/categorias/CategoryFormModal.tsx
+++ b/biblioteca-alejandria/app/(with-navbar)/(panel)/panel-admin/categorias/CategoryFormModal.tsx
@@ -129,9 +129,7 @@ export default function CategoryFormModal({
     <Modal isOpen={isOpen} onClose={onClose} title={title}>
       <form onSubmit={handleSubmit} className="space-y-5">
         {alertState?.message && (
-          <Alert
-            variant={alertState.success ? "success" : "error"}
-            className="!relative !left-0 !translate-x-0">
+          <Alert variant={alertState.success ? "success" : "error"}>
             {alertState.message}
           </Alert>
         )}

--- a/biblioteca-alejandria/app/(with-navbar)/(panel)/panel-admin/editar-libro/EditarLibroContent.tsx
+++ b/biblioteca-alejandria/app/(with-navbar)/(panel)/panel-admin/editar-libro/EditarLibroContent.tsx
@@ -306,8 +306,7 @@ export default function EditarLibroContent() {
 
       {alertState?.message && (
         <Alert
-          variant={alertState.success ? "success" : "error"}
-          className="mb-6 !relative !left-0 !translate-x-0">
+          variant={alertState.success ? "success" : "error"}>
           {alertState.message}
         </Alert>
       )}

--- a/biblioteca-alejandria/app/(with-navbar)/(panel)/panel-admin/inventario/InventarioContent.tsx
+++ b/biblioteca-alejandria/app/(with-navbar)/(panel)/panel-admin/inventario/InventarioContent.tsx
@@ -5,10 +5,8 @@ import Button from "@/components/ui/Button";
 import FilterActionBar from "@/components/ui/FilterActionBar";
 import Alert from "@/components/ui/Alert";
 import {
-  AlertCircle,
   ArrowRightLeft,
   Boxes,
-  CheckCircle,
   Loader2,
   Plus,
 } from "lucide-react";
@@ -146,8 +144,7 @@ export default function InventarioContent() {
   return (
     <main className="flex-1 w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10 md:py-12 relative">
       {errorLoading && (
-        <Alert variant="error" className="mb-6 flex items-center gap-2">
-          <AlertCircle className="w-4 h-4" />
+        <Alert variant="error">
           {errorLoading}
         </Alert>
       )}
@@ -155,13 +152,7 @@ export default function InventarioContent() {
       {feedback && (
         <Alert
           variant={feedback.success ? "success" : "error"}
-          className="mb-6 flex items-center gap-2"
           onClose={() => setFeedback(null)}>
-          {feedback.success ? (
-            <CheckCircle className="w-4 h-4" />
-          ) : (
-            <AlertCircle className="w-4 h-4" />
-          )}
           {feedback.message}
         </Alert>
       )}

--- a/biblioteca-alejandria/app/(with-navbar)/(panel)/panel-admin/libros/LibrosContent.tsx
+++ b/biblioteca-alejandria/app/(with-navbar)/(panel)/panel-admin/libros/LibrosContent.tsx
@@ -3,7 +3,7 @@
 import Button from "@/components/ui/Button";
 import FilterActionBar from "@/components/ui/FilterActionBar";
 import Alert from "@/components/ui/Alert";
-import { Plus, Loader2, AlertCircle, CheckCircle } from "lucide-react";
+import { Plus, Loader2 } from "lucide-react";
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { getLibrosAction, eliminarLibroAction } from "./action";
@@ -125,8 +125,7 @@ export default function LibrosContent() {
     <main className="flex-1 w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10 md:py-12 relative">
       {/* Alerts */}
       {errorLoading && (
-        <Alert variant="error" className="mb-6 flex items-center gap-2">
-          <AlertCircle className="w-4 h-4" />
+        <Alert variant="error">
           {errorLoading}
         </Alert>
       )}
@@ -134,9 +133,7 @@ export default function LibrosContent() {
       {actionResponse?.success === true && (
         <Alert
           variant="success"
-          className="mb-6 flex items-center gap-2"
           onClose={() => setActionResponse(null)}>
-          <CheckCircle className="w-4 h-4" />
           {actionResponse.message || "Operación completada exitosamente"}
         </Alert>
       )}
@@ -144,9 +141,7 @@ export default function LibrosContent() {
       {actionResponse?.success === false && (
         <Alert
           variant="error"
-          className="mb-6 flex items-center gap-2"
           onClose={() => setActionResponse(null)}>
-          <AlertCircle className="w-4 h-4" />
           {actionResponse.message || "Error al procesar la operación"}
         </Alert>
       )}

--- a/biblioteca-alejandria/app/(with-navbar)/(panel)/panel-admin/registrar-libro/RegistrarLibroContent.tsx
+++ b/biblioteca-alejandria/app/(with-navbar)/(panel)/panel-admin/registrar-libro/RegistrarLibroContent.tsx
@@ -284,8 +284,7 @@ export default function RegistrarLibroContent() {
       {/* Alertas */}
       {alertState?.message && (
         <Alert
-          variant={alertState.success ? "success" : "error"}
-          className="mb-6 !relative !left-0 !translate-x-0">
+          variant={alertState.success ? "success" : "error"}>
           {alertState.message}
         </Alert>
       )}

--- a/biblioteca-alejandria/app/(with-navbar)/(panel)/panel-admin/tiendas/TiendasContent.tsx
+++ b/biblioteca-alejandria/app/(with-navbar)/(panel)/panel-admin/tiendas/TiendasContent.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import Button from "@/components/ui/Button";
 import FilterActionBar from "@/components/ui/FilterActionBar";
 import Alert from "@/components/ui/Alert";
-import { AlertCircle, CheckCircle, Loader2, Plus } from "lucide-react";
+import { Plus, Loader2 } from "lucide-react";
 import { useDebounce } from "@/hooks/useDebounce";
 import type {
   TiendaActionResponse,
@@ -143,8 +143,7 @@ export default function TiendasContent() {
   return (
     <main className="flex-1 w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10 md:py-12 relative">
       {errorLoadingTiendas && (
-        <Alert variant="error" className="mb-6 flex items-center gap-2">
-          <AlertCircle className="w-4 h-4" />
+        <Alert variant="error">
           {errorLoadingTiendas}
         </Alert>
       )}
@@ -152,9 +151,7 @@ export default function TiendasContent() {
       {actionResponse?.success && actionResponse.message && (
         <Alert
           variant="success"
-          className="mb-6 flex items-center gap-2"
           onClose={() => setActionResponse(null)}>
-          <CheckCircle className="w-4 h-4" />
           {actionResponse.message}
         </Alert>
       )}
@@ -162,9 +159,7 @@ export default function TiendasContent() {
       {!actionResponse?.success && actionResponse?.message && (
         <Alert
           variant="error"
-          className="mb-6 flex items-center gap-2"
           onClose={() => setActionResponse(null)}>
-          <AlertCircle className="w-4 h-4" />
           {actionResponse.message}
         </Alert>
       )}

--- a/biblioteca-alejandria/app/(with-navbar)/(panel)/panel-root/administradores/AdministradoresContent.tsx
+++ b/biblioteca-alejandria/app/(with-navbar)/(panel)/panel-root/administradores/AdministradoresContent.tsx
@@ -2,7 +2,7 @@
 
 import Button from "@/components/ui/Button";
 import FilterActionBar from "@/components/ui/FilterActionBar";
-import { Plus, CheckCircle, UserX, Loader2, AlertCircle } from "lucide-react";
+import { Plus, CheckCircle, UserX, Loader2 } from "lucide-react";
 import { useState, useEffect } from "react";
 import { getAdminUsersAction, habilitarAdministradores, deshabilitarAdministradores  } from "./action";
 import Alert from "@/components/ui/Alert";
@@ -185,47 +185,25 @@ export default function AdministradoresContent() {
       <main className="flex-1 w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10 md:py-12 relative">
         {/* Alert para errores de carga */}
         {errorLoadingAdmins && (
-          <Alert 
-            variant="error"
-            className="mb-6 flex items-center gap-2"
-          >
-            <AlertCircle className="w-4 h-4" />
+          <Alert variant="error">
             {errorLoadingAdmins}
           </Alert>
         )}
 
-        {/* Alert para operaciones exitosas */}
         {changeStateUserResponse?.success === true && !changeStateUserResponse?.errorIds?.length && (
-          <Alert 
-            variant="success" 
-            className="mb-6 flex items-center gap-2"
-            onClose={() => setChangeStateUserResponse(null)}
-          >
-            <CheckCircle className="w-4 h-4" />
+          <Alert variant="success" onClose={() => setChangeStateUserResponse(null)}>
             {changeStateUserResponse.message || "Operación completada exitosamente"}
           </Alert>
         )}
 
-        {/* Alert para operaciones parcialmente exitosas */}
         {changeStateUserResponse?.success === true && changeStateUserResponse?.errorIds && changeStateUserResponse.errorIds.length > 0 && (
-          <Alert 
-            variant="warning" 
-            className="mb-6 flex items-center gap-2"
-            onClose={() => setChangeStateUserResponse(null)}
-          >
-            <AlertCircle className="w-4 h-4" />
+          <Alert variant="warning" onClose={() => setChangeStateUserResponse(null)}>
             {`Operación parcialmente completada. ${changeStateUserResponse.errorIds.length} administrador(es) no pudieron ser procesados. ${changeStateUserResponse.message || ""}`}
           </Alert>
         )}
 
-        {/* Alert para operaciones fallidas */}
         {changeStateUserResponse?.success === false && (
-          <Alert 
-            variant="error" 
-            className="mb-6 flex items-center gap-2"
-            onClose={() => setChangeStateUserResponse(null)}
-          >
-            <AlertCircle className="w-4 h-4" />
+          <Alert variant="error" onClose={() => setChangeStateUserResponse(null)}>
             {changeStateUserResponse.message || "Error al procesar la operación"}
           </Alert>
         )}

--- a/biblioteca-alejandria/app/(with-navbar)/(panel)/panel-root/auditoria/AuditoriaContent.tsx
+++ b/biblioteca-alejandria/app/(with-navbar)/(panel)/panel-root/auditoria/AuditoriaContent.tsx
@@ -6,7 +6,7 @@ import type { AuditoriaRow } from "@/lib/types/audit";
 import Table from "@/components/ui/Table";
 import type { Column } from "@/components/ui/Table";
 import Alert from "@/components/ui/Alert";
-import { FileClock, Loader2, AlertCircle, Search } from "lucide-react";
+import { FileClock, Loader2, Search } from "lucide-react";
 
 import JsonDataDisplay from "@/components/ui/JsonDataDisplay";
 
@@ -134,8 +134,7 @@ export default function AuditoriaContent() {
   return (
     <main className="flex-1 w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10 md:py-12">
       {error && (
-        <Alert variant="error" className="mb-6 flex items-center gap-2">
-          <AlertCircle className="w-4 h-4" />
+        <Alert variant="error">
           {error}
         </Alert>
       )}

--- a/biblioteca-alejandria/app/globals.css
+++ b/biblioteca-alejandria/app/globals.css
@@ -44,3 +44,27 @@
   border: 1px solid rgba(255, 255, 255, 0.55);
 }
 
+/* ── Toast / Alert overlay animations ─────────────────────────────── */
+@keyframes toastSlideIn {
+  from { opacity: 0; transform: translateY(-150%); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes toastSlideOut {
+  from { opacity: 1; transform: translateY(0); }
+  to   { opacity: 0; transform: translateY(-150%); }
+}
+
+@keyframes toastProgress {
+  from { width: 100%; }
+  to   { width: 0%; }
+}
+
+.toast-slide-in {
+  animation: toastSlideIn 0.3s ease-out both;
+}
+
+.toast-slide-out {
+  animation: toastSlideOut 0.3s ease-in both;
+}
+

--- a/biblioteca-alejandria/app/globals.css
+++ b/biblioteca-alejandria/app/globals.css
@@ -55,11 +55,6 @@
   to   { opacity: 0; transform: translateY(-150%); }
 }
 
-@keyframes toastProgress {
-  from { width: 100%; }
-  to   { width: 0%; }
-}
-
 .toast-slide-in {
   animation: toastSlideIn 0.3s ease-out both;
 }

--- a/biblioteca-alejandria/components/auth/ChangePasswordModal.tsx
+++ b/biblioteca-alejandria/components/auth/ChangePasswordModal.tsx
@@ -146,7 +146,6 @@ export default function ChangePasswordModal({
           <Alert
             key={`error-${submitCount}`}
             variant="error"
-            className="top-1"
           >
             {serverError}
           </Alert>
@@ -155,7 +154,6 @@ export default function ChangePasswordModal({
           <Alert
             key={`success-${submitCount}`}
             variant="success"
-            className="top-1"
           >
             Contraseña actualizada. Redirigiendo al inicio de sesión…
           </Alert>

--- a/biblioteca-alejandria/components/ui/Alert.tsx
+++ b/biblioteca-alejandria/components/ui/Alert.tsx
@@ -1,53 +1,155 @@
 "use client";
 
-import { HTMLAttributes, ReactNode, useEffect, useState } from "react";
+import { ReactNode, useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 
-interface AlertProps extends HTMLAttributes<HTMLDivElement> {
+interface AlertProps {
   variant?: "success" | "error" | "warning" | "info";
-  className?: string;
   children: ReactNode;
   duration?: number;
   onClose?: () => void;
 }
 
+const CHECK_CIRCLE_SVG = (
+  <svg className="w-4 h-4 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <circle cx="12" cy="12" r="10" />
+    <path d="M9 12l2 2 4-4" />
+  </svg>
+);
+
+const X_CIRCLE_SVG = (
+  <svg className="w-4 h-4 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <circle cx="12" cy="12" r="10" />
+    <path d="M15 9l-6 6M9 9l6 6" />
+  </svg>
+);
+
+const ALERT_TRIANGLE_SVG = (
+  <svg className="w-4 h-4 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+    <line x1="12" y1="9" x2="12" y2="13" />
+    <line x1="12" y1="17" x2="12.01" y2="17" />
+  </svg>
+);
+
+const INFO_SVG = (
+  <svg className="w-4 h-4 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <circle cx="12" cy="12" r="10" />
+    <line x1="12" y1="16" x2="12" y2="12" />
+    <line x1="12" y1="8" x2="12.01" y2="8" />
+  </svg>
+);
+
+const X_BUTTON_SVG = (
+  <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M18 6L6 18M6 6l12 12" />
+  </svg>
+);
+
+const VARIANTS = {
+  success: {
+    container: "bg-emerald-50 border-emerald-200 text-emerald-800",
+    icon: CHECK_CIRCLE_SVG,
+  },
+  error: {
+    container: "bg-red-50 border-red-200 text-red-800",
+    icon: X_CIRCLE_SVG,
+  },
+  warning: {
+    container: "bg-amber-50 border-amber-200 text-amber-800",
+    icon: ALERT_TRIANGLE_SVG,
+  },
+  info: {
+    container: "bg-blue-50 border-blue-200 text-blue-800",
+    icon: INFO_SVG,
+  },
+};
+
+const EXIT_DURATION_MS = 300;
+
 export default function Alert({
   variant = "info",
-  className = "",
   children,
-  duration = 2500,
+  duration = 3000,
   onClose,
-  ...props
 }: AlertProps) {
   const [isVisible, setIsVisible] = useState(true);
+  const [isExiting, setIsExiting] = useState(false);
+  const [isMounted, setIsMounted] = useState(false);
+  const [progress, setProgress] = useState(1);
 
   useEffect(() => {
-    if (!duration) return;
+    setIsMounted(true);
+  }, []);
 
-    const timer = setTimeout(() => {
-      setIsVisible(false);
-      if (onClose) onClose();
-    }, duration);
+  useEffect(() => {
+    if (!duration || duration <= 0) return;
 
-    return () => clearTimeout(timer);
+    const startTime = performance.now();
+    let rafId: number;
+
+    const tick = () => {
+      const elapsed = performance.now() - startTime;
+      const remaining = Math.max(0, 1 - elapsed / duration);
+      setProgress(remaining);
+
+      if (remaining <= 0) {
+        setIsExiting(true);
+        setTimeout(() => {
+          setIsVisible(false);
+          if (onClose) onClose();
+        }, EXIT_DURATION_MS);
+      } else {
+        rafId = requestAnimationFrame(tick);
+      }
+    };
+
+    rafId = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(rafId);
   }, [duration, onClose]);
 
-  if (!isVisible) return null;
-
-  const variants = {
-    success: "bg-green-50 border-green-200 text-green-600",
-    error: "bg-red-50 border-red-200 text-red-600",
-    warning: "bg-yellow-50 border-yellow-200 text-yellow-600",
-    info: "bg-blue-50 border-blue-200 text-blue-600",
+  const handleDismiss = () => {
+    setIsExiting(true);
+    setTimeout(() => {
+      setIsVisible(false);
+      if (onClose) onClose();
+    }, EXIT_DURATION_MS);
   };
 
-  const baseStyles = "border px-4 py-3 rounded-lg text-sm z-[100]";
+  if (!isMounted || !isVisible) return null;
 
-  return (
+  const { container, icon } = VARIANTS[variant];
+
+  const alertElement = (
     <div
-      className={`${baseStyles} absolute left-1/2 -translate-x-1/2 ${variants[variant]} ${className}`}
+      className={`fixed top-4 left-0 right-0 mx-auto z-[9999] w-fit max-w-[90vw] md:max-w-md
+        flex items-center gap-3 border px-4 py-3 rounded-lg text-sm shadow-lg
+        ${container}
+        ${isExiting ? "toast-slide-out" : "toast-slide-in"}`}
       role="alert"
-      {...props}>
-      {children}
+      aria-live="assertive"
+    >
+      <div className="flex-shrink-0">{icon}</div>
+      <span className="flex-1 min-w-0 break-words font-medium">{children}</span>
+      <button
+        type="button"
+        onClick={handleDismiss}
+        aria-label="Cerrar notificación"
+        className="ml-1 opacity-60 hover:opacity-100 transition-opacity cursor-pointer p-0.5 rounded hover:bg-black/10"
+      >
+        {X_BUTTON_SVG}
+      </button>
+      {duration > 0 && !isExiting && (
+        <div
+          className="absolute bottom-0 left-0 h-0.5 bg-current opacity-30 rounded-b-lg"
+          style={{ width: `${progress * 100}%` }}
+        />
+      )}
     </div>
   );
+
+  const portalRoot = typeof document !== "undefined" ? document.body : null;
+  if (!portalRoot) return null;
+
+  return createPortal(alertElement, portalRoot);
 }

--- a/biblioteca-alejandria/components/ui/Alert.tsx
+++ b/biblioteca-alejandria/components/ui/Alert.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ReactNode, useEffect, useState } from "react";
+import { ReactNode, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
 interface AlertProps {
@@ -67,42 +67,60 @@ const VARIANTS = {
 
 const EXIT_DURATION_MS = 300;
 
-function useProgressTimer(duration: number, onExpire: () => void) {
+function useProgressTimer(duration: number, isExitingExternal: boolean) {
   const [progress, setProgress] = useState(1);
   const [isExiting, setIsExiting] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const startTimeRef = useRef(0);
+  const onExpireRef = useRef<(() => void) | null>(null);
+
+  const setOnExpire = (fn: () => void) => {
+    onExpireRef.current = fn;
+  };
 
   useEffect(() => {
     if (!duration || duration <= 0) return;
+    if (isExitingExternal) return;
 
-    const startTime = performance.now();
+    startTimeRef.current = performance.now();
     let rafId: number;
+    let tickCount = 0;
 
     const tick = () => {
-      const elapsed = performance.now() - startTime;
+      const elapsed = performance.now() - startTimeRef.current;
       const remaining = Math.max(0, 1 - elapsed / duration);
-      setProgress(remaining);
+
+      if (tickCount % 2 === 0) {
+        setProgress(remaining);
+      }
+      tickCount++;
 
       if (remaining <= 0) {
         setIsExiting(true);
-        setTimeout(onExpire, EXIT_DURATION_MS);
+        timeoutRef.current = setTimeout(() => onExpireRef.current?.(), EXIT_DURATION_MS);
       } else {
         rafId = requestAnimationFrame(tick);
       }
     };
 
     rafId = requestAnimationFrame(tick);
-    return () => cancelAnimationFrame(rafId);
-  }, [duration, onExpire]);
+    return () => {
+      cancelAnimationFrame(rafId);
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, [duration, isExitingExternal]);
 
-  return { progress, isExiting };
+  return { progress, isExiting, setOnExpire };
 }
 
 function useDismissTimer(onDismiss: () => void) {
   const [isExiting, setIsExiting] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const dismiss = () => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
     setIsExiting(true);
-    setTimeout(onDismiss, EXIT_DURATION_MS);
+    timeoutRef.current = setTimeout(onDismiss, EXIT_DURATION_MS);
   };
 
   return { isExiting, dismiss };
@@ -121,14 +139,21 @@ export default function Alert({
     setIsMounted(true);
   }, []);
 
-  const { progress, isExiting } = useProgressTimer(duration, () => {
-    setIsVisible(false);
-  });
-
-  const { dismiss } = useDismissTimer(() => {
+  const { dismiss, isExiting: isExitingFromDismiss } = useDismissTimer(() => {
     setIsVisible(false);
     if (onClose) onClose();
   });
+
+  const { progress, isExiting: isExitingFromTimer, setOnExpire } = useProgressTimer(
+    duration,
+    isExitingFromDismiss
+  );
+
+  useEffect(() => {
+    setOnExpire(() => () => setIsVisible(false));
+  }, [setOnExpire]);
+
+  const isExiting = isExitingFromTimer || isExitingFromDismiss;
 
   if (!isMounted || !isVisible) return null;
 

--- a/biblioteca-alejandria/components/ui/Alert.tsx
+++ b/biblioteca-alejandria/components/ui/Alert.tsx
@@ -67,20 +67,9 @@ const VARIANTS = {
 
 const EXIT_DURATION_MS = 300;
 
-export default function Alert({
-  variant = "info",
-  children,
-  duration = 3000,
-  onClose,
-}: AlertProps) {
-  const [isVisible, setIsVisible] = useState(true);
-  const [isExiting, setIsExiting] = useState(false);
-  const [isMounted, setIsMounted] = useState(false);
+function useProgressTimer(duration: number, onExpire: () => void) {
   const [progress, setProgress] = useState(1);
-
-  useEffect(() => {
-    setIsMounted(true);
-  }, []);
+  const [isExiting, setIsExiting] = useState(false);
 
   useEffect(() => {
     if (!duration || duration <= 0) return;
@@ -95,10 +84,7 @@ export default function Alert({
 
       if (remaining <= 0) {
         setIsExiting(true);
-        setTimeout(() => {
-          setIsVisible(false);
-          if (onClose) onClose();
-        }, EXIT_DURATION_MS);
+        setTimeout(onExpire, EXIT_DURATION_MS);
       } else {
         rafId = requestAnimationFrame(tick);
       }
@@ -106,15 +92,43 @@ export default function Alert({
 
     rafId = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(rafId);
-  }, [duration, onClose]);
+  }, [duration, onExpire]);
 
-  const handleDismiss = () => {
+  return { progress, isExiting };
+}
+
+function useDismissTimer(onDismiss: () => void) {
+  const [isExiting, setIsExiting] = useState(false);
+
+  const dismiss = () => {
     setIsExiting(true);
-    setTimeout(() => {
-      setIsVisible(false);
-      if (onClose) onClose();
-    }, EXIT_DURATION_MS);
+    setTimeout(onDismiss, EXIT_DURATION_MS);
   };
+
+  return { isExiting, dismiss };
+}
+
+export default function Alert({
+  variant = "info",
+  children,
+  duration = 3000,
+  onClose,
+}: AlertProps) {
+  const [isVisible, setIsVisible] = useState(true);
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  const { progress, isExiting } = useProgressTimer(duration, () => {
+    setIsVisible(false);
+  });
+
+  const { dismiss } = useDismissTimer(() => {
+    setIsVisible(false);
+    if (onClose) onClose();
+  });
 
   if (!isMounted || !isVisible) return null;
 
@@ -133,7 +147,7 @@ export default function Alert({
       <span className="flex-1 min-w-0 break-words font-medium">{children}</span>
       <button
         type="button"
-        onClick={handleDismiss}
+        onClick={dismiss}
         aria-label="Cerrar notificación"
         className="ml-1 opacity-60 hover:opacity-100 transition-opacity cursor-pointer p-0.5 rounded hover:bg-black/10"
       >


### PR DESCRIPTION
- Replace absolute positioning with fixed position + createPortal to document.body
- Center alert horizontally with translateX(-50%) regardless of parent container
- Integrate SVG icons per variant (success/error/warning/info) — no manual injection needed
- Add slide-in/slide-out animations with CSS keyframes
- Add dismiss button with aria-label and animated progress bar
- Remove className prop acceptance to enforce design consistency
- Remove obsolete icon imports (AlertCircle, CheckCircle) from 7 consumer files
- Clean up hacks: !relative !left-0 !translate-x-0, top-1, mb-6 flex items-center gap-2
- Fix duplicate Alert blocks in AdministradoresContent
- Fix progress bar to span full width with right-0