### PR TITLE
refactor(models/services): replace ModelResponse with throw/catch err…

### DIFF
--- a/app/(with-navbar)/(panel)/panel-admin/categorias/CategoriasContent.tsx
+++ b/app/(with-navbar)/(panel)/panel-admin/categorias/CategoriasContent.tsx
@@ -43,7 +43,7 @@ export default function CategoriasContent() {
     setErrorLoadingCategorias(null);
 
     try {
-      const response = await getCategoriesAction(page, itemsPerPage, term);
+      const response = await getCategoriesAction({ page, pageSize: itemsPerPage, searchTerm: term });
 
       if (response.success && response.data) {
         setCategoriasData(response.data.data);

--- a/app/(with-navbar)/(panel)/panel-admin/categorias/action.ts
+++ b/app/(with-navbar)/(panel)/panel-admin/categorias/action.ts
@@ -18,20 +18,20 @@ import type {
   CategoryUpdateInput,
   CategoryListResponse,
   CategoryActionResponse,
+  PaginationParams,
 } from "@/lib/types/category";
+import { asCategoryId } from "@/lib/types/category";
 
 /**
  * Server Action: obtiene categorías activas paginadas.
  */
 export async function getCategoriesAction(
-  page: number = 1,
-  pageSize: number = 10,
-  searchTerm?: string,
+  params: PaginationParams,
 ): Promise<CategoryListResponse> {
-  const safePage = toSafePositiveInt(page, 1);
-  const safePageSize = toSafePositiveInt(pageSize, 10);
-  const cleanTerm = searchTerm ? sanitizeText(searchTerm) : undefined;
-  return await fetchCategories(safePage, safePageSize, cleanTerm);
+  const safePage = toSafePositiveInt(params.page, 1);
+  const safePageSize = toSafePositiveInt(params.pageSize, 10);
+  const cleanTerm = params.searchTerm ? sanitizeText(params.searchTerm) : undefined;
+  return await fetchCategories({ page: safePage, pageSize: safePageSize, searchTerm: cleanTerm });
 }
 
 /**
@@ -99,7 +99,7 @@ export async function updateCategoryAction(
     };
   }
 
-  return await updateCategory(categoryId, sanitized);
+  return await updateCategory(asCategoryId(categoryId), sanitized);
 }
 
 /**
@@ -115,5 +115,5 @@ export async function deleteCategoryAction(
     };
   }
 
-  return await deleteCategory(categoryId);
+  return await deleteCategory(asCategoryId(categoryId));
 }

--- a/app/(with-navbar)/(panel)/panel-admin/libros/action.ts
+++ b/app/(with-navbar)/(panel)/panel-admin/libros/action.ts
@@ -242,5 +242,5 @@ export async function eliminarLibroAction(
     return { success: false, message: "ID de libro no válido." };
   }
 
-  return await removeBook(cleanId, sanitizeText(titulo), sanitizeText(estado));
+  return await removeBook(cleanId, sanitizeText(titulo));
 }

--- a/app/(with-navbar)/(panel)/panel-admin/libros/action.ts
+++ b/app/(with-navbar)/(panel)/panel-admin/libros/action.ts
@@ -71,7 +71,7 @@ export async function getCategoryOptionsAction(
   searchTerm?: string,
 ): Promise<ActionResponse & { data?: { value: string; label: string }[] }> {
   const cleanTerm = searchTerm ? sanitizeText(searchTerm) : undefined;
-  const result = await fetchCategories(1, 100, cleanTerm || undefined);
+  const result = await fetchCategories({ page: 1, pageSize: 100, searchTerm: cleanTerm || undefined });
 
   if (!result.success || !result.data) {
     return { success: false, message: result.message || "Error cargando categorías." };

--- a/lib/services/errors.ts
+++ b/lib/services/errors.ts
@@ -1,0 +1,3 @@
+export function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Error desconocido";
+}

--- a/lib/types/category.ts
+++ b/lib/types/category.ts
@@ -4,6 +4,30 @@ import type { ActionResponse, PaginatedResponse } from "./common";
 /** Fila de la tabla `categoria`. */
 export type CategoryRow = Database["public"]["Tables"]["categoria"]["Row"];
 
+// ─── Domain types (eliminate primitive obsession) ─────────────────────
+
+/** ID de categoría — previene confusión con otros IDs numéricos */
+export type CategoryId = number & { readonly __brand: "CategoryId" };
+export function asCategoryId(id: number): CategoryId {
+  if (!Number.isInteger(id) || id <= 0) {
+    throw new Error(`Invalid CategoryId: ${id}`);
+  }
+  return id as CategoryId;
+}
+
+/** Nombre de categoría */
+export type CategoryName = string & { readonly __brand: "CategoryName" };
+export function asCategoryName(name: string): CategoryName {
+  return name as CategoryName;
+}
+
+/** Parámetros de paginación para listados */
+export interface PaginationParams {
+  page: number;
+  pageSize: number;
+  searchTerm?: string;
+}
+
 /** Categoría con la cantidad de libros asociados (para listados). */
 export interface CategoryWithBookCount extends CategoryRow {
   libro_count: number;

--- a/lib/types/common.ts
+++ b/lib/types/common.ts
@@ -3,24 +3,6 @@
  * Centraliza patrones comunes para evitar duplicación (DRY).
  */
 
-// ─── Resultados de operaciones ─────────────────────────────────────
-
-/**
- * Resultado base para operaciones que pueden fallar.
- * Usado en modelos y operaciones internas.
- */
-export interface ModelResult {
-  success: boolean;
-  error?: string;
-}
-
-/**
- * Resultado de operación con ID generado (ej: INSERT con RETURNING id).
- */
-export interface ModelResultWithId extends ModelResult {
-  id?: number;
-}
-
 // ─── Respuestas de API / Server Actions ────────────────────────────
 
 /**

--- a/models/addressModel.ts
+++ b/models/addressModel.ts
@@ -1,5 +1,4 @@
 import { createAdminClient } from "@/lib/supabase/server";
-import type { ModelResult, ModelResultWithId } from "@/lib/types/common";
 
 // ─── Tipos internos ────────────────────────────────────────────────
 
@@ -9,24 +8,15 @@ interface AddressInput {
   detalle?: string;
 }
 
-interface TiendaAddressInfo {
-  tienda_id: string;
-  tienda_nombre: string;
-  direccion_id: number;
-  direccion_formateada: string;
-  place_id: string;
-  detalle_direccion: string | null;
-}
-
 // ─── Operaciones CRUD ──────────────────────────────────────────────
 
 /**
  * Inserta una nueva dirección en la tabla `direccion`.
- * Retorna el `id` generado o un error descriptivo.
+ * Retorna el `id` generado o lanza error.
  */
 export async function createAddress(
   input: AddressInput,
-): Promise<ModelResultWithId> {
+): Promise<number> {
   const adminClient = createAdminClient();
 
   const { data, error } = await adminClient
@@ -41,10 +31,10 @@ export async function createAddress(
 
   if (error) {
     console.error("Error al registrar la dirección:", error);
-    return { success: false, error: error.message };
+    throw error;
   }
 
-  return { success: true, id: data.id };
+  return data.id;
 }
 
 /**
@@ -66,7 +56,7 @@ export async function deleteAddress(id: number): Promise<void> {
 export async function updateAddress(
   id: number,
   input: AddressInput,
-): Promise<ModelResult> {
+): Promise<void> {
   const adminClient = createAdminClient();
 
   const { data, error } = await adminClient
@@ -82,16 +72,15 @@ export async function updateAddress(
 
   if (error) {
     console.error("Error al actualizar dirección:", error);
-    return { success: false, error: error.message };
+    throw error;
   }
 
   if (!data) {
     console.error(
       `Error al actualizar dirección: no se encontró registro con id=${id}`,
     );
-    return { success: false, error: "Dirección no encontrada" };
+    throw new Error("Dirección no encontrada");
   }
-  return { success: true };
 }
 
 export async function isTiendaAddressUsed(placeId: string): Promise<boolean> {

--- a/models/authModel.ts
+++ b/models/authModel.ts
@@ -6,7 +6,6 @@ import { redirect } from "next/navigation";
 import type { AuthError, AuthResponse } from "@supabase/supabase-js";
 
 import { buildOrILikeFilter, escapeLikePattern } from "@/lib/validations/db-utils";
-import type { ModelResult } from "@/lib/types/common";
 import type { AuthSignUpResult } from "@/lib/types/auth";
 import { AdminUserFromView, PaginatedAdminUsers } from "@/lib/types/profile";
 
@@ -105,7 +104,7 @@ export async function adminSignUp(
 export async function setUserRole(
   userId: string,
   rol: Rol
-): Promise<ModelResult> {
+): Promise<void> {
   const adminClient = createAdminClient();
 
   const { error } = await adminClient.auth.admin.updateUserById(userId, {
@@ -114,10 +113,8 @@ export async function setUserRole(
 
   if (error) {
     console.error("Error al asignar rol en app_metadata:", error);
-    return { success: false, error: error.message };
+    throw error;
   }
-
-  return { success: true };
 }
 
 /**

--- a/models/authorModel.ts
+++ b/models/authorModel.ts
@@ -1,5 +1,5 @@
 import { createAdminClient } from "@/lib/supabase/server";
-import type { ModelResult, Paginated } from "@/lib/types/common";
+import type { Paginated } from "@/lib/types/common";
 import type {
   AuthorWithBookCount,
   InsertAuthorPayload,
@@ -27,7 +27,7 @@ function buildAutorPayload(data: {
 async function executeAutorUpdate(
   id: number,
   setClause: Record<string, unknown>
-): Promise<ModelResult> {
+): Promise<void> {
   const adminClient = createAdminClient();
 
   const { error } = await adminClient
@@ -38,10 +38,8 @@ async function executeAutorUpdate(
 
   if (error) {
     console.error("[authorModel] Error en operación autor:", error);
-    return { success: false, error: error.message };
+    throw error;
   }
-
-  return { success: true };
 }
 
 // ─── Escritura ──────────────────────────────────────────────────────
@@ -51,7 +49,7 @@ async function executeAutorUpdate(
  */
 export async function insertAuthor(
   data: InsertAuthorPayload
-): Promise<ModelResult & { id?: number }> {
+): Promise<number> {
   const adminClient = createAdminClient();
 
   const { data: resultData, error } = await adminClient
@@ -62,20 +60,20 @@ export async function insertAuthor(
 
   if (error) {
     console.error("[authorModel] Error al insertar autor:", error);
-    return { success: false, error: error.message };
+    throw error;
   }
 
-  return { success: true, id: resultData?.id };
+  return resultData!.id;
 }
 
 export async function updateAuthor(
   id: number,
   data: UpdateAuthorPayload
-): Promise<ModelResult> {
+): Promise<void> {
   return executeAutorUpdate(id, buildAutorPayload(data));
 }
 
-export async function deleteAuthor(id: number): Promise<ModelResult> {
+export async function deleteAuthor(id: number): Promise<void> {
   return executeAutorUpdate(id, { deleted_at: new Date().toISOString() });
 }
 

--- a/models/authorPreferenceModel.ts
+++ b/models/authorPreferenceModel.ts
@@ -1,5 +1,4 @@
 import { createAdminClient } from "@/lib/supabase/server";
-import type { ModelResult } from "@/lib/types/common";
 import type {
   InsertAuthorPreferencePayload,
   AuthorPreferenceAuthorSummary,
@@ -51,7 +50,7 @@ function normalizeAuthorPreferenceWithDetails(
 
 export async function insertAuthorPreference(
   data: InsertAuthorPreferencePayload
-): Promise<ModelResult & { id?: number }> {
+): Promise<number> {
   const adminClient = createAdminClient();
 
   const { data: resultData, error } = await adminClient
@@ -69,24 +68,22 @@ export async function insertAuthorPreference(
       error
     );
 
-    // Handle unique constraint violation (race condition fallback)
     if (error.code === "23505") {
-      return { success: false, error: "Este autor ya está en tus preferencias." };
+      throw new Error("Este autor ya está en tus preferencias.");
     }
 
-    return { success: false, error: error.message };
+    throw error;
   }
 
-  return { success: true, id: resultData?.id };
+  return resultData!.id;
 }
 
 export async function deleteAuthorPreference(
   id_usuario: string,
   id_autor: number
-): Promise<ModelResult> {
+): Promise<void> {
   const adminClient = createAdminClient();
 
-  // First verify the row exists and belongs to the user
   const { data: existing, error: selectError } = await adminClient
     .from("preferencia_autor")
     .select("id")
@@ -101,14 +98,13 @@ export async function deleteAuthorPreference(
       "[authorPreferenceModel] Error al verificar preferencia:",
       selectError
     );
-    return { success: false, error: selectError.message };
+    throw selectError;
   }
 
   if (!existing) {
-    return { success: false, error: "La preferencia no existe o ya fue eliminada." };
+    throw new Error("La preferencia no existe o ya fue eliminada.");
   }
 
-  // Perform soft delete
   const { data: updatedRows, error } = await adminClient
     .from("preferencia_autor")
     .update({ deleted_at: new Date().toISOString() })
@@ -122,19 +118,17 @@ export async function deleteAuthorPreference(
       "[authorPreferenceModel] Error al eliminar preferencia de autor:",
       error
     );
-    return { success: false, error: error.message };
+    throw error;
   }
 
   if (!updatedRows || updatedRows.length === 0) {
-    return { success: false, error: "La preferencia no existe o ya fue eliminada." };
+    throw new Error("La preferencia no existe o ya fue eliminada.");
   }
-
-  return { success: true };
 }
 
 export async function getAuthorPreferencesByUser(
   id_usuario: string
-): Promise<ModelResult & { data?: AuthorPreferenceWithDetails[] }> {
+): Promise<AuthorPreferenceWithDetails[]> {
   const adminClient = createAdminClient();
 
   const { data, error } = await adminClient
@@ -149,23 +143,20 @@ export async function getAuthorPreferencesByUser(
       "[authorPreferenceModel] Error al obtener preferencias de autor:",
       error
     );
-    return { success: false, error: error.message };
+    throw error;
   }
 
-  return {
-    success: true,
-    data: (data ?? []).map((row) =>
-      normalizeAuthorPreferenceWithDetails(
-        row as AuthorPreferenceRow & { autor?: unknown }
-      )
-    ),
-  };
+  return (data ?? []).map((row) =>
+    normalizeAuthorPreferenceWithDetails(
+      row as AuthorPreferenceRow & { autor?: unknown }
+    )
+  );
 }
 
 export async function checkAuthorPreferenceExists(
   id_usuario: string,
   id_autor: number
-): Promise<ModelResult & { exists?: boolean }> {
+): Promise<boolean> {
   const adminClient = createAdminClient();
 
   const { data, error } = await adminClient
@@ -182,8 +173,8 @@ export async function checkAuthorPreferenceExists(
       "[authorPreferenceModel] Error al verificar preferencia de autor:",
       error
     );
-    return { success: false, error: error.message };
+    throw error;
   }
 
-  return { success: true, exists: !!data };
+  return !!data;
 }

--- a/models/authorPreferenceModel.ts
+++ b/models/authorPreferenceModel.ts
@@ -48,6 +48,32 @@ function normalizeAuthorPreferenceWithDetails(
   };
 }
 
+async function findAuthorPreferenceId(
+  id_usuario: string,
+  id_autor: number
+): Promise<number | null> {
+  const adminClient = createAdminClient();
+
+  const { data, error } = await adminClient
+    .from("preferencia_autor")
+    .select("id")
+    .eq("id_usuario", id_usuario)
+    .eq("id_autor", id_autor)
+    .is("deleted_at", null)
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    console.error(
+      "[authorPreferenceModel] Error al verificar preferencia:",
+      error
+    );
+    throw error;
+  }
+
+  return data?.id ?? null;
+}
+
 export async function insertAuthorPreference(
   data: InsertAuthorPreferencePayload
 ): Promise<number> {
@@ -82,30 +108,13 @@ async function ensureAuthorPreferenceExists(
   id_usuario: string,
   id_autor: number,
 ): Promise<number> {
-  const adminClient = createAdminClient();
+  const id = await findAuthorPreferenceId(id_usuario, id_autor);
 
-  const { data, error } = await adminClient
-    .from("preferencia_autor")
-    .select("id")
-    .eq("id_usuario", id_usuario)
-    .eq("id_autor", id_autor)
-    .is("deleted_at", null)
-    .limit(1)
-    .maybeSingle();
-
-  if (error) {
-    console.error(
-      "[authorPreferenceModel] Error al verificar preferencia:",
-      error,
-    );
-    throw error;
-  }
-
-  if (!data) {
+  if (id === null) {
     throw new Error("La preferencia no existe o ya fue eliminada.");
   }
 
-  return data.id;
+  return id;
 }
 
 export async function deleteAuthorPreference(
@@ -167,24 +176,6 @@ export async function checkAuthorPreferenceExists(
   id_usuario: string,
   id_autor: number
 ): Promise<boolean> {
-  const adminClient = createAdminClient();
-
-  const { data, error } = await adminClient
-    .from("preferencia_autor")
-    .select("id")
-    .eq("id_usuario", id_usuario)
-    .eq("id_autor", id_autor)
-    .is("deleted_at", null)
-    .limit(1)
-    .maybeSingle();
-
-  if (error) {
-    console.error(
-      "[authorPreferenceModel] Error al verificar preferencia de autor:",
-      error
-    );
-    throw error;
-  }
-
-  return !!data;
+  const id = await findAuthorPreferenceId(id_usuario, id_autor);
+  return id !== null;
 }

--- a/models/authorPreferenceModel.ts
+++ b/models/authorPreferenceModel.ts
@@ -78,13 +78,13 @@ export async function insertAuthorPreference(
   return resultData!.id;
 }
 
-export async function deleteAuthorPreference(
+async function ensureAuthorPreferenceExists(
   id_usuario: string,
-  id_autor: number
-): Promise<void> {
+  id_autor: number,
+): Promise<number> {
   const adminClient = createAdminClient();
 
-  const { data: existing, error: selectError } = await adminClient
+  const { data, error } = await adminClient
     .from("preferencia_autor")
     .select("id")
     .eq("id_usuario", id_usuario)
@@ -93,30 +93,40 @@ export async function deleteAuthorPreference(
     .limit(1)
     .maybeSingle();
 
-  if (selectError) {
+  if (error) {
     console.error(
       "[authorPreferenceModel] Error al verificar preferencia:",
-      selectError
+      error,
     );
-    throw selectError;
+    throw error;
   }
 
-  if (!existing) {
+  if (!data) {
     throw new Error("La preferencia no existe o ya fue eliminada.");
   }
+
+  return data.id;
+}
+
+export async function deleteAuthorPreference(
+  id_usuario: string,
+  id_autor: number,
+): Promise<void> {
+  const adminClient = createAdminClient();
+
+  const existingId = await ensureAuthorPreferenceExists(id_usuario, id_autor);
 
   const { data: updatedRows, error } = await adminClient
     .from("preferencia_autor")
     .update({ deleted_at: new Date().toISOString() })
-    .eq("id_usuario", id_usuario)
-    .eq("id_autor", id_autor)
+    .eq("id", existingId)
     .is("deleted_at", null)
     .select("id");
 
   if (error) {
     console.error(
       "[authorPreferenceModel] Error al eliminar preferencia de autor:",
-      error
+      error,
     );
     throw error;
   }

--- a/models/categoryModel.ts
+++ b/models/categoryModel.ts
@@ -5,7 +5,7 @@ import type {
   CategoryWithBookCount,
   CategoryUpdateInput,
 } from "@/lib/types/category";
-import type { ModelResult, ModelResultWithId, Paginated } from "@/lib/types/common";
+import type { Paginated } from "@/lib/types/common";
 import { escapeLikePattern, formatILIKE } from "@/lib/validations/db-utils";
 
 function normalizeCategoryWithBookCount(
@@ -29,7 +29,7 @@ function normalizeCategoryWithBookCount(
  */
 export async function createCategory(
   input: CategoryCreateInput
-): Promise<ModelResultWithId> {
+): Promise<number> {
   const adminClient = createAdminClient();
 
   const { data, error } = await adminClient
@@ -43,10 +43,10 @@ export async function createCategory(
 
   if (error) {
     console.error("Error al crear categoría:", error);
-    return { success: false, error: error.message };
+    throw error;
   }
 
-  return { success: true, id: data.id };
+  return data.id;
 }
 
 /**
@@ -104,7 +104,7 @@ export async function getCategories(
 export async function updateCategoryById(
   categoryId: number,
   input: CategoryUpdateInput
-): Promise<ModelResult> {
+): Promise<void> {
   const adminClient = createAdminClient();
 
   const payload: CategoryUpdateInput = {
@@ -122,14 +122,12 @@ export async function updateCategoryById(
 
   if (error) {
     console.error("Error al actualizar categoría:", error);
-    return { success: false, error: error.message };
+    throw error;
   }
 
   if (!data) {
-    return { success: false, error: "Categoría no encontrada." };
+    throw new Error("Categoría no encontrada.");
   }
-
-  return { success: true };
 }
 
 /**
@@ -137,7 +135,7 @@ export async function updateCategoryById(
  */
 export async function softDeleteCategoryById(
   categoryId: number
-): Promise<ModelResult> {
+): Promise<void> {
   const adminClient = createAdminClient();
 
   const { data, error } = await adminClient
@@ -150,14 +148,12 @@ export async function softDeleteCategoryById(
 
   if (error) {
     console.error("Error al eliminar lógicamente categoría:", error);
-    return { success: false, error: error.message };
+    throw error;
   }
 
   if (!data) {
-    return { success: false, error: "Categoría no encontrada." };
+    throw new Error("Categoría no encontrada.");
   }
-
-  return { success: true };
 }
 
 // ─── Helpers para validaciones en services/categoria ────────────────

--- a/models/categoryModel.ts
+++ b/models/categoryModel.ts
@@ -8,6 +8,37 @@ import type {
 import type { Paginated } from "@/lib/types/common";
 import { escapeLikePattern, formatILIKE } from "@/lib/validations/db-utils";
 
+function buildCategoryQueryOptions(page: number, pageSize: number) {
+  const safePage = Math.max(1, page);
+  const safePageSize = Math.max(1, pageSize);
+  const from = (safePage - 1) * safePageSize;
+  const to = from + safePageSize - 1;
+  return { safePage, safePageSize, from, to };
+}
+
+function applyCategorySearchFilter(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  query: any,
+  searchTerm?: string
+): typeof query {
+  if (!searchTerm || searchTerm.trim() === "") return query;
+  const normalizedSearch = formatILIKE(searchTerm);
+  return query.ilike("nombre", normalizedSearch);
+}
+
+function buildCategoryUpdatePayload(
+  input: CategoryUpdateInput
+): Partial<Pick<CategoryRow, "nombre" | "descripcion">> {
+  const payload: Partial<Pick<CategoryRow, "nombre" | "descripcion">> = {};
+  if (input.nombre !== undefined) payload.nombre = input.nombre;
+  if (input.descripcion !== undefined) payload.descripcion = input.descripcion;
+  return payload;
+}
+
+function hasActiveBooks(data: { id: unknown }[] | null): boolean {
+  return (data?.length ?? 0) > 0;
+}
+
 function normalizeCategoryWithBookCount(
   row: CategoryRow & Record<string, unknown>
 ): CategoryWithBookCount {
@@ -63,30 +94,25 @@ export async function getCategories(
 ): Promise<Paginated<CategoryWithBookCount>> {
   const adminClient = createAdminClient();
 
-  const safePage = Math.max(1, page);
-  const safePageSize = Math.max(1, pageSize);
-  const from = (safePage - 1) * safePageSize;
-  const to = from + safePageSize - 1;
+  const { safePage, safePageSize, from, to } = buildCategoryQueryOptions(page, pageSize);
 
-  let query = adminClient
-    .from("categoria")
-    .select("*, libro(count)", { count: "exact" })
-    .is("deleted_at", null)
-    .is("libro.deleted_at", null)
-    .range(from, to)
-    .order("id", { ascending: false });
-
-  if (searchTerm && searchTerm.trim() !== "") {
-    const normalizedSearch = formatILIKE(searchTerm);
-    query = query.ilike("nombre", normalizedSearch);
-  }
+  const query = applyCategorySearchFilter(
+    adminClient
+      .from("categoria")
+      .select("*, libro(count)", { count: "exact" })
+      .is("deleted_at", null)
+      .is("libro.deleted_at", null)
+      .range(from, to)
+      .order("id", { ascending: false }),
+    searchTerm
+  );
 
   const { data, error, count } = await query;
 
   if (error) throw error;
 
-  const normalized = (data ?? []).map((row) =>
-    normalizeCategoryWithBookCount(row as CategoryRow & Record<string, unknown>)
+  const normalized = (data ?? []).map((row: CategoryRow & Record<string, unknown>) =>
+    normalizeCategoryWithBookCount(row)
   );
 
   return {
@@ -107,10 +133,7 @@ export async function updateCategoryById(
 ): Promise<void> {
   const adminClient = createAdminClient();
 
-  const payload: CategoryUpdateInput = {
-    ...(input.nombre !== undefined ? { nombre: input.nombre } : {}),
-    ...(input.descripcion !== undefined ? { descripcion: input.descripcion } : {}),
-  };
+  const payload = buildCategoryUpdatePayload(input);
 
   const { data, error } = await adminClient
     .from("categoria")
@@ -257,5 +280,5 @@ export async function hasActiveBooksForCategory(
     throw error;
   }
 
-  return (data?.length ?? 0) > 0;
+  return hasActiveBooks(data);
 }

--- a/models/categoryModel.ts
+++ b/models/categoryModel.ts
@@ -1,12 +1,16 @@
 import { createAdminClient } from "@/lib/supabase/server";
 import type {
   CategoryCreateInput,
+  CategoryId,
+  CategoryName,
   CategoryRow,
   CategoryWithBookCount,
   CategoryUpdateInput,
+  PaginationParams,
 } from "@/lib/types/category";
 import type { Paginated } from "@/lib/types/common";
 import { escapeLikePattern, formatILIKE } from "@/lib/validations/db-utils";
+import { asCategoryId, asCategoryName } from "@/lib/types/category";
 
 function buildCategoryQueryOptions(page: number, pageSize: number) {
   const safePage = Math.max(1, page);
@@ -82,16 +86,11 @@ export async function createCategory(
 
 /**
  * Obtiene categorías activas paginadas para el panel.
- *
- * @param page - Número de página (comienza en 1)
- * @param pageSize - Cantidad de resultados por página (por defecto 10)
- * @returns Listado paginado de categorías activas
  */
 export async function getCategories(
-  page: number = 1,
-  pageSize: number = 10,
-  searchTerm?: string
+  params: PaginationParams,
 ): Promise<Paginated<CategoryWithBookCount>> {
+  const { page, pageSize, searchTerm } = params;
   const adminClient = createAdminClient();
 
   const { safePage, safePageSize, from, to } = buildCategoryQueryOptions(page, pageSize);
@@ -128,8 +127,8 @@ export async function getCategories(
  * Actualiza una categoría activa por su ID.
  */
 export async function updateCategoryById(
-  categoryId: number,
-  input: CategoryUpdateInput
+  categoryId: CategoryId,
+  input: CategoryUpdateInput,
 ): Promise<void> {
   const adminClient = createAdminClient();
 
@@ -157,7 +156,7 @@ export async function updateCategoryById(
  * Realiza eliminación lógica de una categoría activa por su ID.
  */
 export async function softDeleteCategoryById(
-  categoryId: number
+  categoryId: CategoryId,
 ): Promise<void> {
   const adminClient = createAdminClient();
 
@@ -186,7 +185,7 @@ export async function softDeleteCategoryById(
  * Helper para validar existencia antes de editar/eliminar.
  */
 export async function getActiveCategoryById(
-  categoryId: number
+  categoryId: CategoryId,
 ): Promise<CategoryRow | null> {
   const adminClient = createAdminClient();
 
@@ -210,7 +209,7 @@ export async function getActiveCategoryById(
  * Helper para validar duplicados al crear.
  */
 export async function getActiveCategoryByExactName(
-  categoryName: string
+  categoryName: CategoryName,
 ): Promise<CategoryRow | null> {
   const adminClient = createAdminClient();
   const exactNamePattern = escapeLikePattern(categoryName);
@@ -236,8 +235,8 @@ export async function getActiveCategoryByExactName(
  * Helper para validar duplicados al editar. no detecta la categoria propia
  */
 export async function getActiveCategoryByExactNameExcludingId(
-  categoryName: string,
-  excludedCategoryId: number //el id propio
+  categoryName: CategoryName,
+  excludedCategoryId: CategoryId,
 ): Promise<CategoryRow | null> {
   const adminClient = createAdminClient();
   const exactNamePattern = escapeLikePattern(categoryName);
@@ -264,7 +263,7 @@ export async function getActiveCategoryByExactNameExcludingId(
  * Helper para validar regla de eliminación lógica.
  */
 export async function hasActiveBooksForCategory(
-  categoryId: number
+  categoryId: CategoryId,
 ): Promise<boolean> {
   const adminClient = createAdminClient();
 

--- a/models/copiaModel.ts
+++ b/models/copiaModel.ts
@@ -299,26 +299,67 @@ export async function getAvailableCopiasByLibroAndStore(
   );
 }
 
+type CopiasFilters = {
+  searchTerm?: string;
+  id_tienda?: string;
+  id_libro?: string;
+};
+
+type PaginationBounds = {
+  safePage: number;
+  safePageSize: number;
+  from: number;
+  to: number;
+};
+
+function buildPaginationBounds(page: number, pageSize: number): PaginationBounds {
+  const safePage = Math.max(1, page);
+  const safePageSize = Math.min(Math.max(1, pageSize), MAX_PAGE_SIZE);
+  const from = (safePage - 1) * safePageSize;
+  const to = from + safePageSize - 1;
+  return { safePage, safePageSize, from, to };
+}
+
+function applyCopiasFilters(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  query: any,
+  filters: CopiasFilters,
+) {
+  if (filters.id_tienda) query = query.eq("id_tienda", filters.id_tienda);
+  if (filters.id_libro) query = query.eq("id_libro", filters.id_libro);
+  if (filters.searchTerm?.trim()) {
+    query = query.ilike("codigo_seq", `%${filters.searchTerm.trim()}%`);
+  }
+  return query;
+}
+
+function applyInventarioFilters(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  query: any,
+  searchTerm?: string,
+  id_tienda?: string,
+) {
+  if (id_tienda) query = query.eq("tienda_id", id_tienda);
+  if (searchTerm?.trim()) {
+    query = query.or(buildOrILikeFilter(["titulo", "autor_libro", "isbn"], searchTerm));
+  }
+  return query;
+}
+
 export async function getInventarioRows(
   searchTerm?: string,
   id_tienda?: string,
 ): Promise<VistaInventarioRow[]> {
   const adminClient = createAdminClient();
 
-  let query = adminClient
-    .from("vista_inventario")
-    .select("*")
-    .order("titulo", { ascending: true, nullsFirst: false });
-
-  if (id_tienda) {
-    query = query.eq("tienda_id", id_tienda);
-  }
-
-  if (searchTerm && searchTerm.trim() !== "") {
-    query = query.or(
-      buildOrILikeFilter(["titulo", "autor_libro", "isbn"], searchTerm),
-    );
-  }
+  const query = applyInventarioFilters(
+    adminClient
+      .from("vista_inventario")
+      .select("*")
+      .order("titulo", { ascending: true, nullsFirst: false }),
+    searchTerm,
+    id_tienda,
+  );
 
   const { data, error } = await query;
 
@@ -339,29 +380,18 @@ export async function getCopias(
 ): Promise<Paginated<CopiaRow>> {
   const adminClient = createAdminClient();
 
-  const safePage = Math.max(1, page);
-  const safePageSize = Math.min(Math.max(1, pageSize), MAX_PAGE_SIZE);
-  const from = (safePage - 1) * safePageSize;
-  const to = from + safePageSize - 1;
+  const { safePage, safePageSize, from, to } = buildPaginationBounds(page, pageSize);
 
-  let query = adminClient
-    .from("copia")
-    .select("*", { count: "exact" })
-    .is("deleted_at", null)
-    .range(from, to)
-    .order("id", { ascending: false });
-
-  if (id_tienda) {
-    query = query.eq("id_tienda", id_tienda);
-  }
-
-  if (id_libro) {
-    query = query.eq("id_libro", id_libro);
-  }
-
-  if (searchTerm && searchTerm.trim() !== "") {
-    query = query.ilike("codigo_seq", `%${searchTerm.trim()}%`);
-  }
+  const filters: CopiasFilters = { searchTerm, id_tienda, id_libro };
+  const query = applyCopiasFilters(
+    adminClient
+      .from("copia")
+      .select("*", { count: "exact" })
+      .is("deleted_at", null)
+      .range(from, to)
+      .order("id", { ascending: false }),
+    filters,
+  );
 
   const { data, error, count } = await query;
 

--- a/models/copiaModel.ts
+++ b/models/copiaModel.ts
@@ -153,16 +153,15 @@ async function handlePartialTransferRollback(
   transferredIds: string[],
   id_tienda_origen: string,
 ): Promise<never> {
-  if (transferredIds.length > 0) {
-    rollbackTransferByQuantity(transferredIds, id_tienda_origen).catch(
-      (rollbackError) => {
-        console.error(
-          "[copiaModel] Error durante el rollback de traslado por cantidad después de una actualización parcial:",
-          rollbackError,
-        );
-      },
+  if (transferredIds.length === 0) {
+    throw new InsufficientStockError(
+      "No hay suficientes copias disponibles en la tienda origen para completar el traslado.",
+      "INSUFFICIENT_STOCK",
+      transferredIds,
     );
   }
+
+  await rollbackTransferByQuantity(transferredIds, id_tienda_origen);
 
   throw new InsufficientStockError(
     "No hay suficientes copias disponibles en la tienda origen para completar el traslado.",

--- a/models/copiaModel.ts
+++ b/models/copiaModel.ts
@@ -1,5 +1,5 @@
 import { createAdminClient } from "@/lib/supabase/server";
-import type { ModelResult, Paginated } from "@/lib/types/common";
+import type { Paginated } from "@/lib/types/common";
 import type {
   CopiaRow,
   InsertCopiaPayload,
@@ -7,7 +7,6 @@ import type {
   UpdateCopiaPayload,
 } from "@/lib/types/copia";
 import type {
-  InventarioCopiaDetalle,
   VistaInventarioRow,
 } from "@/lib/types/inventario";
 import { buildOrILikeFilter } from "@/lib/validations/db-utils";
@@ -19,14 +18,25 @@ export type TransferCopiasByQuantityErrorCode =
   | "INSUFFICIENT_STOCK"
   | "ROLLBACK_FAILED";
 
-export interface TransferCopiasByQuantityModelResult extends ModelResult {
-  transferredIds?: string[];
-  errorCode?: TransferCopiasByQuantityErrorCode;
+export class InsufficientStockError extends Error {
+  readonly errorCode: TransferCopiasByQuantityErrorCode;
+  readonly transferredIds: string[];
+
+  constructor(
+    message: string,
+    errorCode: TransferCopiasByQuantityErrorCode,
+    transferredIds: string[] = []
+  ) {
+    super(message);
+    this.name = "InsufficientStockError";
+    this.errorCode = errorCode;
+    this.transferredIds = transferredIds;
+  }
 }
 
 export async function insertCopias(
   data: InsertCopiaPayload[],
-): Promise<ModelResult> {
+): Promise<void> {
   const adminClient = createAdminClient();
 
   const payload = data.map((copy) => ({
@@ -42,16 +52,14 @@ export async function insertCopias(
 
   if (error) {
     console.error("[copiaModel] Error insertando copias:", error);
-    return { success: false, error: error.message };
+    throw error;
   }
-
-  return { success: true };
 }
 
 export async function updateCopia(
   id: string,
   data: UpdateCopiaPayload,
-): Promise<ModelResult> {
+): Promise<void> {
   const adminClient = createAdminClient();
 
   const { error } = await adminClient
@@ -65,16 +73,14 @@ export async function updateCopia(
 
   if (error) {
     console.error("[copiaModel] Error actualizando copia:", error);
-    return { success: false, error: error.message };
+    throw error;
   }
-
-  return { success: true };
 }
 
 export async function transferCopias(
   ids: string[],
   id_tienda: string,
-): Promise<ModelResult> {
+): Promise<void> {
   const adminClient = createAdminClient();
 
   const { data: updatedRows, error } = await adminClient
@@ -86,17 +92,12 @@ export async function transferCopias(
 
   if (error) {
     console.error("[copiaModel] Error trasladando copias:", error);
-    return { success: false, error: error.message };
+    throw error;
   }
 
   if ((updatedRows ?? []).length !== ids.length) {
-    return {
-      success: false,
-      error: "No se pudieron trasladar todas las copias solicitadas.",
-    };
+    throw new Error("No se pudieron trasladar todas las copias solicitadas.");
   }
-
-  return { success: true };
 }
 
 async function getCopiasForTransferByQuantity(
@@ -150,7 +151,7 @@ async function rollbackTransferByQuantity(
 
 export async function transferCopiasByQuantityAtomic(
   input: TransferCopiasByQuantityInput,
-): Promise<TransferCopiasByQuantityModelResult> {
+): Promise<string[]> {
   const adminClient = createAdminClient();
   const safeQuantity = Math.max(1, input.cantidad);
 
@@ -161,26 +162,23 @@ export async function transferCopiasByQuantityAtomic(
   );
 
   if (copiasForTransfer.length === 0) {
-    return {
-      success: false,
-      errorCode: "INSUFFICIENT_STOCK",
-      error:
-        "No hay copias disponibles en la tienda origen para el libro especificado.",
-    };
+    throw new InsufficientStockError(
+      "No hay copias disponibles en la tienda origen para el libro especificado.",
+      "INSUFFICIENT_STOCK"
+    );
   }
 
-  // PASO 2: Actualizar solo esos IDs específicos
   const { data: updatedRows, error: updateError } = await adminClient
     .from("copia")
     .update({ id_tienda: input.id_tienda_destino })
-    .in("id", copiasForTransfer) // Usamos .in() para afectar solo a los que encontramos
+    .in("id", copiasForTransfer)
     .select("id");
 
   if (updateError) throw updateError;
 
   const transferredIds = (updatedRows ?? []).map((row) => row.id);
   if (transferredIds.length === safeQuantity) {
-    return { success: true, transferredIds };
+    return transferredIds;
   }
 
   if (transferredIds.length > 0) {
@@ -194,47 +192,35 @@ export async function transferCopiasByQuantityAtomic(
     );
   }
 
-  return {
-    success: false,
-    errorCode: "INSUFFICIENT_STOCK",
-    error:
-      "No hay suficientes copias disponibles en la tienda origen para completar el traslado.",
-  };
+  throw new InsufficientStockError(
+    "No hay suficientes copias disponibles en la tienda origen para completar el traslado.",
+    "INSUFFICIENT_STOCK",
+    transferredIds
+  );
 }
 
-export async function softDeleteCopias(ids: string[]): Promise<ModelResult> {
-  // Usamos el Admin Client para asegurar permisos de escritura
+export async function softDeleteCopias(ids: string[]): Promise<void> {
   const adminClient = createAdminClient();
 
   const { data: updatedRows, error } = await adminClient
-    .from("copia") // Asegúrate de que sea "copia" (singular) como en tu otra función
+    .from("copia")
     .update({ deleted_at: new Date().toISOString() })
     .in("id", ids)
     .is("deleted_at", null)
-    .select("id"); // Solo actualiza las que no estén ya borradas
+    .select("id");
 
   if (error) {
     console.error("[copiaModel] Error en softDeleteManyCopiasModel:", error);
-    return { success: false, error: error.message };
+    throw error;
   }
 
   if ((updatedRows ?? []).length !== ids.length) {
-    return {
-      success: false,
-      error: "No se pudieron eliminar todas las copias solicitadas.",
-    };
+    throw new Error("No se pudieron eliminar todas las copias solicitadas.");
   }
-  return { success: true };
 }
 // ─── Lectura ───────────────────────────────────────────────────────
 
-function getRelationName(
-  value: { nombre?: string } | { nombre?: string }[] | null,
-): string {
-  if (!value) return "Sin tienda asociada";
-  if (Array.isArray(value)) return value[0]?.nombre ?? "Sin tienda asociada";
-  return value.nombre ?? "Sin tienda asociada";
-}
+// ─── Escritura ─────────────────────────────────────────────────────
 
 export async function getCopiaById(id: string): Promise<CopiaRow | null> {
   const adminClient = createAdminClient();

--- a/models/copiaModel.ts
+++ b/models/copiaModel.ts
@@ -149,6 +149,28 @@ async function rollbackTransferByQuantity(
   }
 }
 
+async function handlePartialTransferRollback(
+  transferredIds: string[],
+  id_tienda_origen: string,
+): Promise<never> {
+  if (transferredIds.length > 0) {
+    rollbackTransferByQuantity(transferredIds, id_tienda_origen).catch(
+      (rollbackError) => {
+        console.error(
+          "[copiaModel] Error durante el rollback de traslado por cantidad después de una actualización parcial:",
+          rollbackError,
+        );
+      },
+    );
+  }
+
+  throw new InsufficientStockError(
+    "No hay suficientes copias disponibles en la tienda origen para completar el traslado.",
+    "INSUFFICIENT_STOCK",
+    transferredIds,
+  );
+}
+
 export async function transferCopiasByQuantityAtomic(
   input: TransferCopiasByQuantityInput,
 ): Promise<string[]> {
@@ -181,21 +203,9 @@ export async function transferCopiasByQuantityAtomic(
     return transferredIds;
   }
 
-  if (transferredIds.length > 0) {
-    rollbackTransferByQuantity(transferredIds, input.id_tienda_origen).catch(
-      (rollbackError) => {
-        console.error(
-          "[copiaModel] Error durante el rollback de traslado por cantidad después de una actualización parcial:",
-          rollbackError,
-        );
-      },
-    );
-  }
-
-  throw new InsufficientStockError(
-    "No hay suficientes copias disponibles en la tienda origen para completar el traslado.",
-    "INSUFFICIENT_STOCK",
-    transferredIds
+  return handlePartialTransferRollback(
+    transferredIds,
+    input.id_tienda_origen,
   );
 }
 

--- a/models/historicoModel.ts
+++ b/models/historicoModel.ts
@@ -1,5 +1,5 @@
 import { createAdminClient } from "@/lib/supabase/server";
-import type { ModelResult, Paginated } from "@/lib/types/common";
+import type { Paginated } from "@/lib/types/common";
 import type { CopiaRow } from "@/lib/types/copia";
 import type {
   HistoricoSyncBookSnapshot,
@@ -12,7 +12,7 @@ import { MAX_PAGE_SIZE } from "@/lib/validations/rules";
 
 export async function insertHistorico(
   data: InsertHistoricoPayload
-): Promise<ModelResult> {
+): Promise<void> {
   const adminClient = createAdminClient();
 
   const { error } = await adminClient.from("historico").insert({
@@ -23,17 +23,15 @@ export async function insertHistorico(
 
   if (error) {
     console.error("[historicoModel] Error insertando histórico:", error);
-    return { success: false, error: error.message };
+    throw error;
   }
-
-  return { success: true };
 }
 
 export async function insertHistoricoBatch(
   data: InsertHistoricoPayload[],
-): Promise<ModelResult> {
+): Promise<void> {
   if (data.length === 0) {
-    return { success: true };
+    return;
   }
 
   const adminClient = createAdminClient();
@@ -48,13 +46,11 @@ export async function insertHistoricoBatch(
 
   if (error) {
     console.error("[historicoModel] Error insertando históricos en lote:", error);
-    return { success: false, error: error.message };
+    throw error;
   }
-
-  return { success: true };
 }
 
-export async function deleteHistoricoByLibroId(id_libro: string): Promise<ModelResult> {
+export async function deleteHistoricoByLibroId(id_libro: string): Promise<void> {
   const adminClient = createAdminClient();
 
   const { error } = await adminClient
@@ -64,10 +60,8 @@ export async function deleteHistoricoByLibroId(id_libro: string): Promise<ModelR
 
   if (error) {
     console.error("[historicoModel] Error eliminando histórico por id_libro:", error);
-    return { success: false, error: error.message };
+    throw error;
   }
-
-  return { success: true };
 }
 
 // ─── Lectura ───────────────────────────────────────────────────────

--- a/models/historicoModel.ts
+++ b/models/historicoModel.ts
@@ -8,6 +8,12 @@ import type {
 } from "@/lib/types/historico";
 import { MAX_PAGE_SIZE } from "@/lib/validations/rules";
 
+function normalizePagination(page: number, pageSize: number) {
+  const safePage = Math.max(1, page);
+  const safePageSize = Math.min(Math.max(1, pageSize), MAX_PAGE_SIZE);
+  return { safePage, safePageSize };
+}
+
 // ─── Escritura ─────────────────────────────────────────────────────
 
 export async function insertHistorico(
@@ -73,8 +79,7 @@ export async function getHistoricoByLibro(
 ): Promise<Paginated<HistoricoRow>> {
   const adminClient = createAdminClient();
 
-  const safePage = Math.max(1, page);
-  const safePageSize = Math.min(Math.max(1, pageSize), MAX_PAGE_SIZE);
+  const { safePage, safePageSize } = normalizePagination(page, pageSize);
   const from = (safePage - 1) * safePageSize;
   const to = from + safePageSize - 1;
 
@@ -131,6 +136,16 @@ type LibroHistoricoSyncRow = {
     | null;
 };
 
+function countAvailableCopies(
+  copias: Pick<CopiaRow, "estado" | "deleted_at">[] | null,
+): number {
+  return (
+    copias?.filter(
+      (copy) => copy.deleted_at === null && copy.estado === "disponible",
+    ).length ?? 0
+  );
+}
+
 export async function getHistoricoSyncSnapshotsByLibros(
   libroIds: string[],
 ): Promise<HistoricoSyncBookSnapshot[]> {
@@ -164,10 +179,7 @@ export async function getHistoricoSyncSnapshotsByLibros(
 
   return rows.map((row) => ({
     id_libro: row.id,
-    available_count:
-      row.copia?.filter(
-        (copy) => copy.deleted_at === null && copy.estado === "disponible",
-      ).length ?? 0,
+    available_count: countAvailableCopies(row.copia),
     latest_estado: row.historico?.[0]?.estado ?? null,
   }));
 }

--- a/models/libroModel.ts
+++ b/models/libroModel.ts
@@ -6,7 +6,7 @@ import type {
   LibroWithRelations,
   UpdateLibroPayload,
 } from "@/lib/types/libro";
-import type { ModelResult, Paginated } from "@/lib/types/common";
+import type { Paginated } from "@/lib/types/common";
 import { MAX_PAGE_SIZE } from "@/lib/validations/rules";
 import {
   buildOrILikeFilter,
@@ -16,8 +16,6 @@ import {
 import type { CondicionLibro } from "@/lib/types/libro";
 
 type LibroUpdateRow = Database["public"]["Tables"]["libro"]["Update"];
-type LibroId = Database["public"]["Tables"]["libro"]["Row"]["id"];
-type LibroModelResultWithId = ModelResult & { id?: LibroId };
 
 function extractRelationName(value: unknown): string | null {
   if (!value) return null;
@@ -86,7 +84,7 @@ async function getMatchingCategoryIds(searchTerm: string): Promise<number[]> {
  */
 export async function createLibro(
   input: InsertLibroPayload,
-): Promise<LibroModelResultWithId> {
+): Promise<string> {
   const adminClient = createAdminClient();
 
   const { data, error } = await adminClient
@@ -110,10 +108,10 @@ export async function createLibro(
 
   if (error) {
     console.error("[libroModel] Error al crear libro:", error);
-    return { success: false, error: error.message };
+    throw error;
   }
 
-  return { success: true, id: data.id };
+  return data.id;
 }
 
 /**
@@ -289,7 +287,7 @@ export async function getActiveLibroById(
 export async function updateLibroById(
   libroId: string,
   input: UpdateLibroPayload,
-): Promise<ModelResult> {
+): Promise<void> {
   const adminClient = createAdminClient();
 
   const payload: LibroUpdateRow = {
@@ -310,10 +308,7 @@ export async function updateLibroById(
   };
 
   if (Object.keys(payload).length === 0) {
-    return {
-      success: false,
-      error: "Debes enviar al menos un campo para actualizar.",
-    };
+    throw new Error("Debes enviar al menos un campo para actualizar.");
   }
 
   const { data, error } = await adminClient
@@ -326,20 +321,18 @@ export async function updateLibroById(
 
   if (error) {
     console.error("[libroModel] Error al actualizar libro:", error);
-    return { success: false, error: error.message };
+    throw error;
   }
 
   if (!data) {
-    return { success: false, error: "Libro no encontrado." };
+    throw new Error("Libro no encontrado.");
   }
-
-  return { success: true };
 }
 
 /**
  * Realiza eliminacion logica de un libro activo por su ID.
  */
-export async function softDeleteLibroById(libroId: string): Promise<ModelResult> {
+export async function softDeleteLibroById(libroId: string): Promise<void> {
   const adminClient = createAdminClient();
 
   const { data, error } = await adminClient
@@ -352,14 +345,12 @@ export async function softDeleteLibroById(libroId: string): Promise<ModelResult>
 
   if (error) {
     console.error("[libroModel] Error al eliminar libro:", error);
-    return { success: false, error: error.message };
+    throw error;
   }
 
   if (!data) {
-    return { success: false, error: "Libro no encontrado." };
+    throw new Error("Libro no encontrado.");
   }
-
-  return { success: true };
 }
 
 /**
@@ -431,10 +422,9 @@ export async function checkLibroDuplicateInfo(
  * Rollback (Hard Delete) de un libro y sus dependencias creadas en transacciones fallidas.
  * Se eliminan primero copias, historico, noticias y finalmente el libro debido a NO ACTION FK.
  */
-export async function rollbackLibro(id_libro: string): Promise<ModelResult> {
+export async function rollbackLibro(id_libro: string): Promise<void> {
   const adminClient = createAdminClient();
 
-  // Borrar copias asociadas al libro
   const { error: copiaErr } = await adminClient
     .from("copia")
     .delete()
@@ -443,7 +433,6 @@ export async function rollbackLibro(id_libro: string): Promise<ModelResult> {
     console.error("[libroModel] Error eliminando copias en rollback:", copiaErr);
   }
 
-  // Borrar historicos
   const { error: histErr } = await adminClient
     .from("historico")
     .delete()
@@ -452,7 +441,6 @@ export async function rollbackLibro(id_libro: string): Promise<ModelResult> {
     console.error("[libroModel] Error eliminando historico en rollback:", histErr);
   }
 
-  // Borrar noticias
   const { error: noticErr } = await adminClient
     .from("noticias")
     .delete()
@@ -461,7 +449,6 @@ export async function rollbackLibro(id_libro: string): Promise<ModelResult> {
     console.error("[libroModel] Error eliminando noticias en rollback:", noticErr);
   }
 
-  // Borrar libro principal
   const { error: libroErr } = await adminClient
     .from("libro")
     .delete()
@@ -469,8 +456,6 @@ export async function rollbackLibro(id_libro: string): Promise<ModelResult> {
 
   if (libroErr) {
     console.error("[libroModel] Error eliminando libro principal en rollback:", libroErr);
-    return { success: false, error: libroErr.message };
+    throw libroErr;
   }
-
-  return { success: true };
 }

--- a/models/libroModel.ts
+++ b/models/libroModel.ts
@@ -17,6 +17,26 @@ import type { CondicionLibro } from "@/lib/types/libro";
 
 type LibroUpdateRow = Database["public"]["Tables"]["libro"]["Update"];
 
+function buildLibroUpdatePayload(
+  input: UpdateLibroPayload,
+): Partial<LibroUpdateRow> {
+  const payload: Partial<LibroUpdateRow> = {};
+  if (input.titulo !== undefined) payload.titulo = input.titulo;
+  if (input.isbn !== undefined) payload.isbn = input.isbn;
+  if (input.idioma !== undefined) payload.idioma = input.idioma;
+  if (input.sinopsis !== undefined) payload.sipnosis = input.sinopsis;
+  if (input.paginas !== undefined) payload.paginas = input.paginas;
+  if (input.precio !== undefined) payload.precio = input.precio;
+  if (input.estado !== undefined) payload.estado = input.estado;
+  if (input.id_autor !== undefined) payload.id_autor = input.id_autor;
+  if (input.id_categoria !== undefined) payload.id_categoria = input.id_categoria;
+  if (input.fecha_publicacion !== undefined)
+    payload.fecha_publicacion = input.fecha_publicacion;
+  if (input.editorial !== undefined) payload.editorial = input.editorial;
+  if (input.id_modeloRA !== undefined) payload.id_modeloRA = input.id_modeloRA;
+  return payload;
+}
+
 function extractRelationName(value: unknown): string | null {
   if (!value) return null;
 
@@ -290,22 +310,7 @@ export async function updateLibroById(
 ): Promise<void> {
   const adminClient = createAdminClient();
 
-  const payload: LibroUpdateRow = {
-    ...(input.titulo !== undefined ? { titulo: input.titulo } : {}),
-    ...(input.isbn !== undefined ? { isbn: input.isbn } : {}),
-    ...(input.idioma !== undefined ? { idioma: input.idioma } : {}),
-    ...(input.sinopsis !== undefined ? { sipnosis: input.sinopsis } : {}),
-    ...(input.paginas !== undefined ? { paginas: input.paginas } : {}),
-    ...(input.precio !== undefined ? { precio: input.precio } : {}),
-    ...(input.estado !== undefined ? { estado: input.estado } : {}),
-    ...(input.id_autor !== undefined ? { id_autor: input.id_autor } : {}),
-    ...(input.id_categoria !== undefined ? { id_categoria: input.id_categoria } : {}),
-    ...(input.fecha_publicacion !== undefined
-      ? { fecha_publicacion: input.fecha_publicacion }
-      : {}),
-    ...(input.editorial !== undefined ? { editorial: input.editorial } : {}),
-    ...(input.id_modeloRA !== undefined ? { id_modeloRA: input.id_modeloRA } : {}),
-  };
+  const payload = buildLibroUpdatePayload(input);
 
   if (Object.keys(payload).length === 0) {
     throw new Error("Debes enviar al menos un campo para actualizar.");

--- a/models/modeloRAModel.ts
+++ b/models/modeloRAModel.ts
@@ -55,19 +55,25 @@ export async function getActiveModeloRAById(
   return data;
 }
 
+function buildModeloRAUpdatePayload(
+  input: UpdateModeloRAPayload,
+): Partial<UpdateModeloRAPayload> {
+  const payload: Partial<UpdateModeloRAPayload> = {};
+  if (input.dimensiones !== undefined) payload.dimensiones = input.dimensiones;
+  if (input.texturas !== undefined) payload.texturas = input.texturas;
+  return payload;
+}
+
 /**
  * Actualiza un modelo RA activo por su ID.
  */
 export async function updateModeloRAById(
   modeloRAId: number,
-  input: UpdateModeloRAPayload
+  input: UpdateModeloRAPayload,
 ): Promise<void> {
   const adminClient = createAdminClient();
 
-  const payload: UpdateModeloRAPayload = {
-    ...(input.dimensiones !== undefined ? { dimensiones: input.dimensiones } : {}),
-    ...(input.texturas !== undefined ? { texturas: input.texturas } : {}),
-  };
+  const payload: UpdateModeloRAPayload = buildModeloRAUpdatePayload(input);
 
   if (Object.keys(payload).length === 0) {
     throw new Error("Debes enviar al menos un campo para actualizar.");

--- a/models/modeloRAModel.ts
+++ b/models/modeloRAModel.ts
@@ -4,14 +4,13 @@ import type {
   ModeloRARow,
   UpdateModeloRAPayload,
 } from "@/lib/types/modelo_ra";
-import type { ModelResult, ModelResultWithId } from "@/lib/types/common";
 
 /**
  * Inserta un nuevo modelo RA en la tabla `modelo_ra`.
  */
 export async function createModeloRA(
   input: InsertModeloRAPayload
-): Promise<ModelResultWithId> {
+): Promise<number> {
   const adminClient = createAdminClient();
 
   const { data, error } = await adminClient
@@ -25,10 +24,10 @@ export async function createModeloRA(
 
   if (error) {
     console.error("[modeloRAModel] Error al crear modelo RA:", error);
-    return { success: false, error: error.message };
+    throw error;
   }
 
-  return { success: true, id: data.id };
+  return data.id;
 }
 
 /**
@@ -62,7 +61,7 @@ export async function getActiveModeloRAById(
 export async function updateModeloRAById(
   modeloRAId: number,
   input: UpdateModeloRAPayload
-): Promise<ModelResult> {
+): Promise<void> {
   const adminClient = createAdminClient();
 
   const payload: UpdateModeloRAPayload = {
@@ -71,10 +70,7 @@ export async function updateModeloRAById(
   };
 
   if (Object.keys(payload).length === 0) {
-    return {
-      success: false,
-      error: "Debes enviar al menos un campo para actualizar.",
-    };
+    throw new Error("Debes enviar al menos un campo para actualizar.");
   }
 
   const { data, error } = await adminClient
@@ -87,14 +83,12 @@ export async function updateModeloRAById(
 
   if (error) {
     console.error("[modeloRAModel] Error al actualizar modelo RA:", error);
-    return { success: false, error: error.message };
+    throw error;
   }
 
   if (!data) {
-    return { success: false, error: "Modelo RA no encontrado." };
+    throw new Error("Modelo RA no encontrado.");
   }
-
-  return { success: true };
 }
 
 /**
@@ -102,7 +96,7 @@ export async function updateModeloRAById(
  */
 export async function softDeleteModeloRAById(
   modeloRAId: number
-): Promise<ModelResult> {
+): Promise<void> {
   const adminClient = createAdminClient();
 
   const { data, error } = await adminClient
@@ -115,12 +109,10 @@ export async function softDeleteModeloRAById(
 
   if (error) {
     console.error("[modeloRAModel] Error al eliminar modelo RA:", error);
-    return { success: false, error: error.message };
+    throw error;
   }
 
   if (!data) {
-    return { success: false, error: "Modelo RA no encontrado." };
+    throw new Error("Modelo RA no encontrado.");
   }
-
-  return { success: true };
 }

--- a/models/noticiaModel.ts
+++ b/models/noticiaModel.ts
@@ -1,5 +1,5 @@
 import { createAdminClient } from "@/lib/supabase/server";
-import type { ModelResult, Paginated } from "@/lib/types/common";
+import type { Paginated } from "@/lib/types/common";
 import type {
   NoticiaId,
   LibroId,
@@ -62,7 +62,7 @@ function mapNoticiaConPrecio(row: NoticiaConLibroPrecio): NoticiaWithPrecio {
 
 export async function insertNoticia(
   data: InsertNoticiaPayload
-): Promise<ModelResult> {
+): Promise<void> {
   const adminClient = createAdminClient();
 
   const { error } = await adminClient.from("noticias").insert({
@@ -75,16 +75,14 @@ export async function insertNoticia(
 
   if (error) {
     console.error("[noticiaModel] Error insertando noticia:", error);
-    return { success: false, error: error.message };
+    throw error;
   }
-
-  return { success: true };
 }
 
 export async function updateNoticia(
   id: NoticiaId,
   data: UpdateNoticiaPayload
-): Promise<ModelResult> {
+): Promise<void> {
   const adminClient = createAdminClient();
 
   const { error } = await adminClient
@@ -100,13 +98,11 @@ export async function updateNoticia(
 
   if (error) {
     console.error("[noticiaModel] Error actualizando noticia:", error);
-    return { success: false, error: error.message };
+    throw error;
   }
-
-  return { success: true };
 }
 
-export async function softDeleteNoticia(id: NoticiaId): Promise<ModelResult> {
+export async function softDeleteNoticia(id: NoticiaId): Promise<void> {
   const adminClient = createAdminClient();
 
   const { error } = await adminClient
@@ -117,13 +113,11 @@ export async function softDeleteNoticia(id: NoticiaId): Promise<ModelResult> {
 
   if (error) {
     console.error("[noticiaModel] Error eliminando noticia:", error);
-    return { success: false, error: error.message };
+    throw error;
   }
-
-  return { success: true };
 }
 
-export async function softDeleteNoticiaByLibroId(id_libro: LibroId): Promise<ModelResult> {
+export async function softDeleteNoticiaByLibroId(id_libro: LibroId): Promise<void> {
   const adminClient = createAdminClient();
 
   const { error } = await adminClient
@@ -134,10 +128,8 @@ export async function softDeleteNoticiaByLibroId(id_libro: LibroId): Promise<Mod
 
   if (error) {
     console.error("[noticiaModel] Error eliminando noticia por id_libro:", error);
-    return { success: false, error: error.message };
+    throw error;
   }
-
-  return { success: true };
 }
 
 export async function getNoticiaById(

--- a/models/tiendaModel.ts
+++ b/models/tiendaModel.ts
@@ -1,8 +1,6 @@
 import { createAdminClient } from "@/lib/supabase/server";
 import type {
-  ModelResult,
   Paginated,
-  DataResponse,
   DataResponseArray,
 } from "@/lib/types/common";
 import type { Database } from "@/lib/types/supabase";
@@ -16,10 +14,6 @@ import type {
 } from "@/lib/types/tienda";
 import { escapeLikePattern, formatILIKE } from "@/lib/validations/db-utils";
 import { MAX_PAGE_SIZE } from "@/lib/validations/rules";
-
-interface ModelResultWithStringId extends ModelResult {
-  id?: string;
-}
 
 type TiendaListRow = TiendaRow & {
   direccion: Pick<
@@ -55,7 +49,7 @@ function normalizeTiendaWithDireccion(row: TiendaListRow): TiendaWithDireccion {
  */
 export async function createTienda(
   input: InsertTiendaPayload,
-): Promise<ModelResultWithStringId> {
+): Promise<string> {
   const adminClient = createAdminClient();
 
   const { data, error } = await adminClient
@@ -71,10 +65,10 @@ export async function createTienda(
 
   if (error) {
     console.error("[tiendaModel] Error al crear tienda:", error);
-    return { success: false, error: error.message };
+    throw error;
   }
 
-  return { success: true, id: data.id };
+  return data.id;
 }
 
 /**
@@ -185,7 +179,7 @@ export async function getDefaultTienda(): Promise<TiendaGlobal | null> {
 export async function updateTiendaById(
   tiendaId: string,
   input: UpdateTiendaPayload,
-): Promise<ModelResult> {
+): Promise<void> {
   const adminClient = createAdminClient();
 
   const payload: Database["public"]["Tables"]["tienda"]["Update"] = {
@@ -202,10 +196,7 @@ export async function updateTiendaById(
   };
 
   if (Object.keys(payload).length === 0) {
-    return {
-      success: false,
-      error: "Debes enviar al menos un campo para actualizar.",
-    };
+    throw new Error("Debes enviar al menos un campo para actualizar.");
   }
 
   const { data, error } = await adminClient
@@ -218,14 +209,12 @@ export async function updateTiendaById(
 
   if (error) {
     console.error("[tiendaModel] Error al actualizar tienda:", error);
-    return { success: false, error: error.message };
+    throw error;
   }
 
   if (!data) {
-    return { success: false, error: "Tienda no encontrada." };
+    throw new Error("Tienda no encontrada.");
   }
-
-  return { success: true };
 }
 
 /**
@@ -233,7 +222,7 @@ export async function updateTiendaById(
  */
 export async function softDeleteTiendaById(
   tiendaId: string,
-): Promise<ModelResult> {
+): Promise<void> {
   const adminClient = createAdminClient();
 
   const { data, error } = await adminClient
@@ -246,14 +235,12 @@ export async function softDeleteTiendaById(
 
   if (error) {
     console.error("[tiendaModel] Error al eliminar tienda:", error);
-    return { success: false, error: error.message };
+    throw error;
   }
 
   if (!data) {
-    return { success: false, error: "Tienda no encontrada." };
+    throw new Error("Tienda no encontrada.");
   }
-
-  return { success: true };
 }
 
 /**

--- a/models/tiendaModel.ts
+++ b/models/tiendaModel.ts
@@ -174,6 +174,21 @@ export async function getDefaultTienda(): Promise<TiendaGlobal | null> {
 }
 
 /**
+ * Construye el payload para actualizar una tienda.
+ */
+function buildTiendaUpdatePayload(
+  input: UpdateTiendaPayload,
+): Database["public"]["Tables"]["tienda"]["Update"] {
+  const payload: Partial<Database["public"]["Tables"]["tienda"]["Update"]> = {};
+  if (input.nombre !== undefined) payload.nombre = input.nombre;
+  if (input.horario !== undefined) {
+    payload.horario = input.horario as unknown as Database["public"]["Tables"]["tienda"]["Update"]["horario"];
+  }
+  if (input.id_direccion !== undefined) payload.id_direccion = input.id_direccion;
+  return payload;
+}
+
+/**
  * Actualiza una tienda activa por su ID.
  */
 export async function updateTiendaById(
@@ -182,18 +197,7 @@ export async function updateTiendaById(
 ): Promise<void> {
   const adminClient = createAdminClient();
 
-  const payload: Database["public"]["Tables"]["tienda"]["Update"] = {
-    ...(input.nombre !== undefined ? { nombre: input.nombre } : {}),
-    ...(input.horario !== undefined
-      ? {
-          horario:
-            input.horario as unknown as Database["public"]["Tables"]["tienda"]["Update"]["horario"],
-        }
-      : {}),
-    ...(input.id_direccion !== undefined
-      ? { id_direccion: input.id_direccion }
-      : {}),
-  };
+  const payload = buildTiendaUpdatePayload(input);
 
   if (Object.keys(payload).length === 0) {
     throw new Error("Debes enviar al menos un campo para actualizar.");

--- a/models/userModel.ts
+++ b/models/userModel.ts
@@ -1,6 +1,5 @@
 import { createAdminClient } from "@/lib/supabase/server";
 import type { PersonalData, Genero } from "@/lib/types/auth";
-import type { ModelResult } from "@/lib/types/common";
 
 /** Datos crudos del perfil obtenidos por join usuario + dirección. */
 export interface RawUserProfile {
@@ -70,7 +69,7 @@ export async function updateUserProfile(
     genero: Genero;
     id_direccion?: number;
   }
-): Promise<ModelResult> {
+): Promise<void> {
   const adminClient = createAdminClient();
 
   const { error } = await adminClient
@@ -87,10 +86,8 @@ export async function updateUserProfile(
 
   if (error) {
     console.error("Error al actualizar perfil del usuario:", error);
-    return { success: false, error: error.message };
+    throw error;
   }
-
-  return { success: true };
 }
 
 // ─── Validaciones de unicidad ──────────────────────────────────────
@@ -121,7 +118,7 @@ export async function checkDniExists(dni: string): Promise<boolean> {
  */
 export async function checkUsernameExists(
   username: string
-): Promise<{ exists: boolean; error?: string }> {
+): Promise<boolean> {
   const adminClient = createAdminClient();
 
   const { data, error } = await adminClient.rpc("check_username_exists", {
@@ -130,10 +127,10 @@ export async function checkUsernameExists(
 
   if (error) {
     console.error("Error al verificar username:", error);
-    return { exists: false, error: error.message };
+    throw error;
   }
 
-  return { exists: !!data };
+  return !!data;
 }
 
 // ─── Operaciones CRUD ──────────────────────────────────────────────
@@ -148,7 +145,7 @@ export async function createUserProfile(
   userId: string,
   personalData: PersonalData,
   addressId: number
-): Promise<ModelResult> {
+): Promise<void> {
   const adminClient = createAdminClient();
 
   const { error } = await adminClient.from("usuario").upsert({
@@ -164,10 +161,8 @@ export async function createUserProfile(
 
   if (error) {
     console.error("Error al registrar el perfil del usuario:", error);
-    return { success: false, error: error.message };
+    throw error;
   }
-
-  return { success: true };
 }
 
 /**
@@ -176,7 +171,7 @@ export async function createUserProfile(
  */
 export async function deleteUserProfile(
   userId: string
-): Promise<ModelResult> {
+): Promise<void> {
   const adminClient = createAdminClient();
 
   const { error } = await adminClient
@@ -186,8 +181,6 @@ export async function deleteUserProfile(
 
   if (error) {
     console.error("Error al eliminar el perfil del usuario:", error);
-    return { success: false, error: error.message };
+    throw error;
   }
-
-  return { success: true };
 }

--- a/services/auth/registrationService.ts
+++ b/services/auth/registrationService.ts
@@ -54,6 +54,77 @@ export async function notifyNewAdmin(email: string, password: string): Promise<M
   }
 }
 
+async function validateAdminRegistration(rol: Rol): Promise<AuthSignUpResult> {
+  if (rol === Rol.CLIENTE) return { success: true, data: undefined };
+  const isRoot = await isCurrentUserRoot();
+  if (!isRoot) {
+    return {
+      success: false,
+      errors: { form: "No tienes permisos para registrar nuevos usuarios." },
+      message: "Permisos insuficientes para registrar usuarios.",
+    };
+  }
+  return { success: true, data: undefined };
+}
+
+async function validateUsernameAvailability(
+  username: string | null,
+): Promise<AuthSignUpResult> {
+  if (!username) return { success: true, data: undefined };
+  try {
+    const usernameExists = await checkUsernameExists(username);
+    if (usernameExists) {
+      return {
+        success: false,
+        errors: { usuario: "El nombre de usuario ya está en uso." },
+        message: "El nombre de usuario ya está en uso.",
+      };
+    }
+  } catch (error) {
+    return {
+      success: false,
+      errors: { form: `Error verificando usuario: ${getErrorMessage(error)}` },
+      message: `Error al verificar el nombre de usuario: ${getErrorMessage(error)}`,
+    };
+  }
+  return { success: true, data: undefined };
+}
+
+async function assignRoleIfNeeded(
+  userId: string,
+  rol: Rol,
+  correo: string,
+  contrasena: string,
+): Promise<AuthSignUpResult> {
+  if (rol === Rol.CLIENTE) return { success: true, data: undefined };
+
+  try {
+    await setUserRole(userId, rol);
+  } catch (error) {
+    await deleteAuthUser(userId);
+    return {
+      success: false,
+      errors: { form: `Error al asignar rol: ${getErrorMessage(error)}` },
+      message: `Error al asignar rol: ${getErrorMessage(error)}`,
+    };
+  }
+
+  if (rol === Rol.ADMINISTRADOR) {
+    const emailResult = await notifyNewAdmin(correo, contrasena);
+    if (!emailResult.success) {
+      await deleteAuthUser(userId);
+      return {
+        success: false,
+        errors: {
+          form: `Error al enviar correo de credenciales: ${emailResult.message}`,
+        },
+        message: `Error al enviar correo de credenciales: ${emailResult.message}`,
+      };
+    }
+  }
+  return { success: true, data: undefined };
+}
+
 export async function registerAuthUser(
   credentialData: CredentialData,
   rol: Rol,
@@ -62,50 +133,31 @@ export async function registerAuthUser(
   if (process.env.NODE_ENV !== "production") {
     console.debug("Iniciando registro de usuario en entorno no productivo");
   }
-  if (rol !== Rol.CLIENTE) {
-    const isRoot = await isCurrentUserRoot();
-    if (!isRoot) {
-      return {
-        success: false,
-        errors: { form: "No tienes permisos para registrar nuevos usuarios." },
-        message: "Permisos insuficientes para registrar usuarios.",
-      };
-    }
-  }
 
-  if (username) {
-    let usernameExists: boolean;
-    try {
-      usernameExists = await checkUsernameExists(username);
-    } catch (error) {
-      return {
-        success: false,
-        errors: { form: `Error verificando usuario: ${getErrorMessage(error)}` },
-        message: `Error al verificar el nombre de usuario: ${getErrorMessage(error)}`,
-      };
-    }
-    if (usernameExists) {
-      return {
-        success: false,
-        errors: { usuario: "El nombre de usuario ya está en uso." },
-        message: "El nombre de usuario ya está en uso.",
-      };
-    }
-  }
+  const permCheck = await validateAdminRegistration(rol);
+  if (!permCheck.success) return permCheck;
 
-  const authModelResult = rol !== Rol.CLIENTE 
-    ? await adminSignUp(credentialData.correo, credentialData.contrasena, username)
-    : await signUp(credentialData.correo, credentialData.contrasena, username);
+  const usernameCheck = await validateUsernameAvailability(username);
+  if (!usernameCheck.success) return usernameCheck;
 
-  if (!authModelResult.success) {
+  const authResult =
+    rol !== Rol.CLIENTE
+      ? await adminSignUp(
+          credentialData.correo,
+          credentialData.contrasena,
+          username,
+        )
+      : await signUp(credentialData.correo, credentialData.contrasena, username);
+
+  if (!authResult.success) {
     return {
       success: false,
-      errors: authModelResult.errors,
-      message: authModelResult.message,
+      errors: authResult.errors,
+      message: authResult.message,
     };
   }
 
-  const userId = authModelResult.data?.user?.id;
+  const userId = authResult.data?.user?.id;
   if (!userId) {
     return {
       success: false,
@@ -114,34 +166,15 @@ export async function registerAuthUser(
     };
   }
 
-  if (rol !== Rol.CLIENTE) {
-    try {
-      await setUserRole(userId, rol);
-    } catch (error) {
-      await deleteAuthUser(userId);
-      return {
-        success: false,
-        errors: { form: `Error al asignar rol: ${getErrorMessage(error)}` },
-        message: `Error al asignar rol: ${getErrorMessage(error)}`,
-      };
-    }
-  }
+  const roleResult = await assignRoleIfNeeded(
+    userId,
+    rol,
+    credentialData.correo,
+    credentialData.contrasena,
+  );
+  if (!roleResult.success) return roleResult;
 
-  if (rol === Rol.ADMINISTRADOR) {
-    console.log("Enviando correo de credenciales al nuevo administrador");
-    const emailResult = await notifyNewAdmin(credentialData.correo, credentialData.contrasena);
-    if (!emailResult.success) {
-      //rollback
-      await deleteAuthUser(userId);
-      return {
-        success: false,
-        errors: { form: `Error al enviar correo de credenciales: ${emailResult.message}` },
-        message: `Error al enviar correo de credenciales: ${emailResult.message}`,
-      };
-    }
-  }
-
-  return authModelResult;
+  return authResult;
 }
 export async function register(
   credentialData: CredentialData,

--- a/services/auth/registrationService.ts
+++ b/services/auth/registrationService.ts
@@ -23,6 +23,7 @@ import {
 
 import { sendEmail } from "@/lib/services/email";
 import { newAdminHtmlTemplate } from "@/lib/templates/email-templates";
+import { getErrorMessage } from "@/lib/services/errors";
 /**
  * Orquesta el flujo completo de registro de usuario:
  *
@@ -73,15 +74,17 @@ export async function registerAuthUser(
   }
 
   if (username) {
-    const usernameCheck = await checkUsernameExists(username);
-    if (usernameCheck.error) {
+    let usernameExists: boolean;
+    try {
+      usernameExists = await checkUsernameExists(username);
+    } catch (error) {
       return {
         success: false,
-        errors: { form: `Error verificando usuario. ${usernameCheck.error}` },
-        message: `Error al verificar el nombre de usuario. ${usernameCheck.error}`,
+        errors: { form: `Error verificando usuario: ${getErrorMessage(error)}` },
+        message: `Error al verificar el nombre de usuario: ${getErrorMessage(error)}`,
       };
     }
-    if (usernameCheck.exists) {
+    if (usernameExists) {
       return {
         success: false,
         errors: { usuario: "El nombre de usuario ya está en uso." },
@@ -112,14 +115,14 @@ export async function registerAuthUser(
   }
 
   if (rol !== Rol.CLIENTE) {
-    const roleResult = await setUserRole(userId, rol);
-    if (!roleResult.success) {
-      // Rollback: eliminar usuario Auth
+    try {
+      await setUserRole(userId, rol);
+    } catch (error) {
       await deleteAuthUser(userId);
       return {
         success: false,
-        errors: { form: `Error al asignar rol: ${roleResult.error}` },
-        message: `Error al asignar rol: ${roleResult.error}`,
+        errors: { form: `Error al asignar rol: ${getErrorMessage(error)}` },
+        message: `Error al asignar rol: ${getErrorMessage(error)}`,
       };
     }
   }
@@ -148,7 +151,15 @@ export async function register(
   try {
 
     // ── Paso 1: Validar unicidad ────────────────────────────────
-    const dniExists = await checkDniExists(personalData.dni);
+    let dniExists: boolean;
+    try {
+      dniExists = await checkDniExists(personalData.dni);
+    } catch (error) {
+      return {
+        success: false,
+        errors: { form: `Error verificando DNI: ${getErrorMessage(error)}` },
+      };
+    }
     if (dniExists) {
       return {
         success: false,
@@ -177,35 +188,34 @@ export async function register(
     }
 
     // ── Paso 4: Crear dirección ─────────────────────────────────
-    const addressResult = await createAddress({
-      direccion: personalData.direccion,
-      placeId: personalData.direccion_place_id,
-      detalle: personalData.direccion_detalle,
-    });
-
-    if (!addressResult.success || !addressResult.id) {
-      // Rollback: eliminar usuario Auth
+    let addressId: number;
+    try {
+      addressId = await createAddress({
+        direccion: personalData.direccion,
+        placeId: personalData.direccion_place_id,
+        detalle: personalData.direccion_detalle,
+      });
+    } catch (error) {
       await deleteAuthUser(userId);
       return {
         success: false,
-        errors: { direccion: `Error al registrar dirección: ${addressResult.error}` },
+        errors: { direccion: `Error al registrar dirección: ${getErrorMessage(error)}` },
       };
     }
 
     // ── Paso 5: Crear perfil de usuario ─────────────────────────
-    const profileResult = await createUserProfile(
-      userId,
-      personalData,
-      addressResult.id
-    );
-
-    if (!profileResult.success) {
-      // Rollback completo: eliminar usuario Auth y dirección
+    try {
+      await createUserProfile(
+        userId,
+        personalData,
+        addressId
+      );
+    } catch (error) {
       await deleteAuthUser(userId);
-      await deleteAddress(addressResult.id);
+      await deleteAddress(addressId);
       return {
         success: false,
-        errors: { form: `Error al crear perfil: ${profileResult.error}` },
+        errors: { form: `Error al crear perfil: ${getErrorMessage(error)}` },
       };
     }
 

--- a/services/authors/authorService.ts
+++ b/services/authors/authorService.ts
@@ -1,3 +1,4 @@
+import { getErrorMessage } from "@/lib/services/errors";
 import {
   insertAuthor,
   updateAuthor,
@@ -48,13 +49,11 @@ export async function createAuthor(
     };
   }
 
-  const result = await insertAuthor(data);
-
-  if (!result.success) {
-    return {
-      success: false,
-      message: result.error || "Error al crear el autor.",
-    };
+  let insertedId: number;
+  try {
+    insertedId = await insertAuthor(data);
+  } catch (error) {
+    return { success: false, message: getErrorMessage(error) };
   }
 
   const actor = await getCurrentUser();
@@ -67,7 +66,7 @@ export async function createAuthor(
     });
   }
 
-  return { success: true, message: "Autor creado exitosamente.", id: result.id };
+  return { success: true, message: "Autor creado exitosamente.", id: insertedId };
 }
 
 /**
@@ -100,13 +99,10 @@ export async function editAuthor(
     };
   }
 
-  const result = await updateAuthor(id, data);
-
-  if (!result.success) {
-    return {
-      success: false,
-      message: result.error || "Error al actualizar el autor.",
-    };
+  try {
+    await updateAuthor(id, data);
+  } catch (error) {
+    return { success: false, message: getErrorMessage(error) };
   }
 
   const actor = await getCurrentUser();
@@ -152,13 +148,10 @@ export async function removeAuthor(
     };
   }
 
-  const result = await deleteAuthor(id);
-
-  if (!result.success) {
-    return {
-      success: false,
-      message: result.error || "Error al eliminar el autor.",
-    };
+  try {
+    await deleteAuthor(id);
+  } catch (error) {
+    return { success: false, message: getErrorMessage(error) };
   }
 
   const actor = await getCurrentUser();

--- a/services/categories/categoryService.ts
+++ b/services/categories/categoryService.ts
@@ -10,9 +10,12 @@ import {
 } from "@/models/categoryModel";
 import type {
   CategoryCreateInput,
+  CategoryId,
+  CategoryName,
   CategoryUpdateInput,
   CategoryListResponse,
   CategoryActionResponse,
+  PaginationParams,
 } from "@/lib/types/category";
 import type { ActionResponse } from "@/lib/types/common";
 import { requireAdminRole } from "@/lib/validations/server-auth";
@@ -21,6 +24,7 @@ import { logAdminAction } from "@/services/admin/auditService";
 import { AccionAdministrador } from "@/lib/types/audit";
 import { sanitizeNullableText, sanitizeText } from "@/lib/validations/rules";
 import { getErrorMessage } from "@/lib/services/errors";
+import { asCategoryId, asCategoryName } from "@/lib/types/category";
 
 function normalizeCategoryName(name: string): string {
   return sanitizeText(name);
@@ -43,6 +47,10 @@ type AuditDescriptionBuilder = (
 type CategoryMutationContext = {
   preMutationValidator: PreMutationValidator | null;
   mutation: MutationFn;
+  messages: {
+    errorMessageOnFailure: string;
+    successMessage: string;
+  };
 };
 
 type CategoryAuditContext = {
@@ -51,11 +59,9 @@ type CategoryAuditContext = {
 };
 
 async function executeAdminCategoryMutation(
-  categoryId: number,
+  categoryId: CategoryId,
   context: CategoryMutationContext,
   audit: CategoryAuditContext,
-  errorMessageOnFailure: string,
-  successMessage: string,
 ): Promise<CategoryActionResponse> {
   const roleCheck = await requireAdminRole();
   if (!roleCheck.success) return roleCheck;
@@ -95,7 +101,7 @@ async function executeAdminCategoryMutation(
     });
   }
 
-  return { success: true, message: successMessage };
+  return { success: true, message: context.messages.successMessage };
 }
 
 function isSameName(left: string, right: string): boolean {
@@ -108,7 +114,7 @@ function isSameName(left: string, right: string): boolean {
 async function validateAndBuildNameUpdate(
   newName: string | undefined,
   currentName: string,
-  categoryId: number,
+  categoryId: CategoryId,
   payload: CategoryUpdateInput,
 ): Promise<ActionResponse | null> {
   if (newName === undefined) return null;
@@ -118,7 +124,7 @@ async function validateAndBuildNameUpdate(
   if (isSameName(normalizedName, currentName)) return null;
 
   const duplicatedCategory = await getActiveCategoryByExactNameExcludingId(
-    normalizedName,
+    asCategoryName(normalizedName),
     categoryId,
   );
 
@@ -138,20 +144,17 @@ async function validateAndBuildNameUpdate(
  * Obtiene categorías activas paginadas para el panel administrativo.
  */
 export async function fetchCategories(
-  page: number = 1,
-  pageSize: number = 10,
-  searchTerm?: string,
+  params: PaginationParams,
 ): Promise<CategoryListResponse> {
   try {
     const roleCheck = await requireAdminRole();
     if (!roleCheck.success) return roleCheck;
 
-    const normalizedSearch = searchTerm ? normalizeCategoryName(searchTerm) : "";
-    const data = await getCategoriesModel(
-      page,
-      pageSize,
-      normalizedSearch || undefined,
-    );
+    const data = await getCategoriesModel({
+      page: params.page,
+      pageSize: params.pageSize,
+      searchTerm: params.searchTerm ? normalizeCategoryName(params.searchTerm) : undefined,
+    });
     return {
       success: true,
       data,
@@ -180,7 +183,7 @@ export async function createCategory(
     const normalizedName = normalizeCategoryName(input.nombre ?? "");
 
     const duplicatedCategory =
-      await getActiveCategoryByExactName(normalizedName);
+      await getActiveCategoryByExactName(asCategoryName(normalizedName));
     if (duplicatedCategory) {
       return {
         success: false,
@@ -237,7 +240,7 @@ export async function createCategory(
  * Edita una categoría activa y valida nombre duplicado cuando cambia.
  */
 export async function updateCategory(
-  categoryId: number,
+  categoryId: CategoryId,
   input: CategoryUpdateInput,
 ): Promise<CategoryActionResponse> {
   const hasName = input.nombre !== undefined;
@@ -270,10 +273,15 @@ export async function updateCategory(
 
   return executeAdminCategoryMutation(
     categoryId,
-    { preMutationValidator: null, mutation },
+    {
+      preMutationValidator: null,
+      mutation,
+      messages: {
+        errorMessageOnFailure: "No se pudo actualizar la categoría.",
+        successMessage: "Categoría actualizada exitosamente.",
+      },
+    },
     { buildAuditDescription, auditAction: AccionAdministrador.MODIFICAR },
-    "No se pudo actualizar la categoría.",
-    "Categoría actualizada exitosamente.",
   );
 }
 
@@ -281,7 +289,7 @@ export async function updateCategory(
  * Elimina lógicamente una categoría activa si no tiene libros asociados.
  */
 export async function deleteCategory(
-  categoryId: number,
+  categoryId: CategoryId,
 ): Promise<CategoryActionResponse> {
   const preMutationValidator: PreMutationValidator = async () => {
     const hasLinkedBooks = await hasActiveBooksForCategory(categoryId);
@@ -307,9 +315,14 @@ export async function deleteCategory(
 
   return executeAdminCategoryMutation(
     categoryId,
-    { preMutationValidator, mutation },
+    {
+      preMutationValidator,
+      mutation,
+      messages: {
+        errorMessageOnFailure: "No se pudo eliminar la categoría.",
+        successMessage: "Categoría eliminada exitosamente.",
+      },
+    },
     { buildAuditDescription, auditAction: AccionAdministrador.ELIMINAR },
-    "No se pudo eliminar la categoría.",
-    "Categoría eliminada exitosamente.",
   );
 }

--- a/services/categories/categoryService.ts
+++ b/services/categories/categoryService.ts
@@ -40,12 +40,20 @@ type AuditDescriptionBuilder = (
   category: NonNullable<Awaited<ReturnType<typeof getActiveCategoryById>>>
 ) => string;
 
+type CategoryMutationContext = {
+  preMutationValidator: PreMutationValidator | null;
+  mutation: MutationFn;
+};
+
+type CategoryAuditContext = {
+  buildAuditDescription: AuditDescriptionBuilder;
+  auditAction: AccionAdministrador;
+};
+
 async function executeAdminCategoryMutation(
   categoryId: number,
-  preMutationValidator: PreMutationValidator | null,
-  mutation: MutationFn,
-  buildAuditDescription: AuditDescriptionBuilder,
-  auditAction: AccionAdministrador,
+  context: CategoryMutationContext,
+  audit: CategoryAuditContext,
   errorMessageOnFailure: string,
   successMessage: string,
 ): Promise<CategoryActionResponse> {
@@ -61,14 +69,14 @@ async function executeAdminCategoryMutation(
     };
   }
 
-  if (preMutationValidator) {
-    const validationResult = await preMutationValidator();
+  if (context.preMutationValidator) {
+    const validationResult = await context.preMutationValidator();
     if (validationResult !== null && !validationResult.success) {
       return validationResult;
     }
   }
 
-  const mutationResult = await mutation(currentCategory);
+  const mutationResult = await context.mutation(currentCategory);
   if (mutationResult !== undefined) {
     return mutationResult as ActionResponse;
   }
@@ -77,8 +85,8 @@ async function executeAdminCategoryMutation(
   if (actor) {
     await logAdminAction({
       actorId: actor.id,
-      action: auditAction,
-      description: buildAuditDescription(currentCategory),
+      action: audit.auditAction,
+      description: audit.buildAuditDescription(currentCategory),
       entity: {
         id: String(categoryId),
         entity_type: "categoría",
@@ -262,10 +270,8 @@ export async function updateCategory(
 
   return executeAdminCategoryMutation(
     categoryId,
-    null,
-    mutation,
-    buildAuditDescription,
-    AccionAdministrador.MODIFICAR,
+    { preMutationValidator: null, mutation },
+    { buildAuditDescription, auditAction: AccionAdministrador.MODIFICAR },
     "No se pudo actualizar la categoría.",
     "Categoría actualizada exitosamente.",
   );
@@ -301,10 +307,8 @@ export async function deleteCategory(
 
   return executeAdminCategoryMutation(
     categoryId,
-    preMutationValidator,
-    mutation,
-    buildAuditDescription,
-    AccionAdministrador.ELIMINAR,
+    { preMutationValidator, mutation },
+    { buildAuditDescription, auditAction: AccionAdministrador.ELIMINAR },
     "No se pudo eliminar la categoría.",
     "Categoría eliminada exitosamente.",
   );

--- a/services/categories/categoryService.ts
+++ b/services/categories/categoryService.ts
@@ -14,6 +14,7 @@ import type {
   CategoryListResponse,
   CategoryActionResponse,
 } from "@/lib/types/category";
+import type { ActionResponse } from "@/lib/types/common";
 import { requireAdminRole } from "@/lib/validations/server-auth";
 import { getCurrentUser } from "@/models/authModel";
 import { logAdminAction } from "@/services/admin/auditService";
@@ -36,6 +37,35 @@ function isSameName(left: string, right: string): boolean {
     normalizeCategoryName(left).toLocaleLowerCase() ===
     normalizeCategoryName(right).toLocaleLowerCase()
   );
+}
+
+async function validateAndBuildNameUpdate(
+  newName: string | undefined,
+  currentName: string,
+  categoryId: number,
+  payload: CategoryUpdateInput,
+): Promise<ActionResponse | null> {
+  if (newName === undefined) return null;
+
+  const normalizedName = normalizeCategoryName(newName);
+
+  if (isSameName(normalizedName, currentName)) return null;
+
+  const duplicatedCategory = await getActiveCategoryByExactNameExcludingId(
+    normalizedName,
+    categoryId,
+  );
+
+  if (duplicatedCategory) {
+    return {
+      success: false,
+      errors: { nombre: "Ya existe una categoría con ese nombre." },
+      message: "Ya existe una categoría con ese nombre.",
+    };
+  }
+
+  payload.nombre = normalizedName;
+  return null;
 }
 
 /**
@@ -165,25 +195,15 @@ export async function updateCategory(
     const payload: CategoryUpdateInput = {};
 
     if (hasName) {
-      const normalizedName = normalizeCategoryName(input.nombre ?? "");
-
-      if (!isSameName(normalizedName, currentCategory.nombre)) {
-        const duplicatedCategory =
-          await getActiveCategoryByExactNameExcludingId(
-            normalizedName,
-            categoryId,
-          );
-
-        if (duplicatedCategory) {
-          return {
-            success: false,
-            errors: { nombre: "Ya existe una categoría con ese nombre." },
-            message: "Ya existe una categoría con ese nombre.",
-          };
-        }
+      const nameValidationResult = await validateAndBuildNameUpdate(
+        input.nombre,
+        currentCategory.nombre,
+        categoryId,
+        payload,
+      );
+      if (nameValidationResult !== null && !nameValidationResult.success) {
+        return nameValidationResult;
       }
-
-      payload.nombre = normalizedName;
     }
 
     if (hasDescription) {

--- a/services/categories/categoryService.ts
+++ b/services/categories/categoryService.ts
@@ -19,6 +19,7 @@ import { getCurrentUser } from "@/models/authModel";
 import { logAdminAction } from "@/services/admin/auditService";
 import { AccionAdministrador } from "@/lib/types/audit";
 import { sanitizeNullableText, sanitizeText } from "@/lib/validations/rules";
+import { getErrorMessage } from "@/lib/services/errors";
 
 function normalizeCategoryName(name: string): string {
   return sanitizeText(name);
@@ -93,15 +94,16 @@ export async function createCategory(
       };
     }
 
-    const result = await createCategoryModel({
-      nombre: normalizedName,
-      descripcion: normalizeDescription(input.descripcion),
-    });
-
-    if (!result.success) {
+    let createdId: number;
+    try {
+      createdId = await createCategoryModel({
+        nombre: normalizedName,
+        descripcion: normalizeDescription(input.descripcion),
+      });
+    } catch (error) {
       return {
         success: false,
-        errors: { form: result.error ?? "No se pudo crear la categoría." },
+        errors: { form: getErrorMessage(error) },
         message: "No se pudo crear la categoría.",
       };
     }
@@ -113,7 +115,7 @@ export async function createCategory(
         action: AccionAdministrador.CREAR,
         description: `Se creó la categoría "${normalizedName}".`,
         entity: {
-          id: String(result.id),
+          id: String(createdId),
           entity_type: "categoría",
           display_name: normalizedName,
         },
@@ -123,7 +125,7 @@ export async function createCategory(
     return {
       success: true,
       message: "Categoría creada exitosamente.",
-      id: result.id,
+      id: createdId,
     };
   } catch (error: unknown) {
     console.error("Error inesperado al crear categoría:", error);
@@ -188,11 +190,12 @@ export async function updateCategory(
       payload.descripcion = normalizeDescription(input.descripcion);
     }
 
-    const result = await updateCategoryById(categoryId, payload);
-    if (!result.success) {
+    try {
+      await updateCategoryById(categoryId, payload);
+    } catch (error) {
       return {
         success: false,
-        errors: { form: result.error ?? "No se pudo actualizar la categoría." },
+        errors: { form: getErrorMessage(error) },
         message: "No se pudo actualizar la categoría.",
       };
     }
@@ -258,11 +261,12 @@ export async function deleteCategory(
       };
     }
 
-    const result = await softDeleteCategoryById(categoryId);
-    if (!result.success) {
+    try {
+      await softDeleteCategoryById(categoryId);
+    } catch (error) {
       return {
         success: false,
-        errors: { form: result.error ?? "No se pudo eliminar la categoría." },
+        errors: { form: getErrorMessage(error) },
         message: "No se pudo eliminar la categoría.",
       };
     }

--- a/services/categories/categoryService.ts
+++ b/services/categories/categoryService.ts
@@ -32,6 +32,64 @@ function normalizeDescription(
   return sanitizeNullableText(description);
 }
 
+type PreMutationValidator = () => Promise<ActionResponse | null>;
+type MutationFn = (
+  currentCategory: NonNullable<Awaited<ReturnType<typeof getActiveCategoryById>>>
+) => Promise<ActionResponse | void>;
+type AuditDescriptionBuilder = (
+  category: NonNullable<Awaited<ReturnType<typeof getActiveCategoryById>>>
+) => string;
+
+async function executeAdminCategoryMutation(
+  categoryId: number,
+  preMutationValidator: PreMutationValidator | null,
+  mutation: MutationFn,
+  buildAuditDescription: AuditDescriptionBuilder,
+  auditAction: AccionAdministrador,
+  errorMessageOnFailure: string,
+  successMessage: string,
+): Promise<CategoryActionResponse> {
+  const roleCheck = await requireAdminRole();
+  if (!roleCheck.success) return roleCheck;
+
+  const currentCategory = await getActiveCategoryById(categoryId);
+  if (!currentCategory) {
+    return {
+      success: false,
+      errors: { form: "La categoría no existe o ya fue eliminada." },
+      message: "La categoría no existe o ya fue eliminada.",
+    };
+  }
+
+  if (preMutationValidator) {
+    const validationResult = await preMutationValidator();
+    if (validationResult !== null && !validationResult.success) {
+      return validationResult;
+    }
+  }
+
+  const mutationResult = await mutation(currentCategory);
+  if (mutationResult !== undefined) {
+    return mutationResult as ActionResponse;
+  }
+
+  const actor = await getCurrentUser();
+  if (actor) {
+    await logAdminAction({
+      actorId: actor.id,
+      action: auditAction,
+      description: buildAuditDescription(currentCategory),
+      entity: {
+        id: String(categoryId),
+        entity_type: "categoría",
+        display_name: currentCategory.nombre,
+      },
+    });
+  }
+
+  return { success: true, message: successMessage };
+}
+
 function isSameName(left: string, right: string): boolean {
   return (
     normalizeCategoryName(left).toLocaleLowerCase() ===
@@ -92,8 +150,7 @@ export async function fetchCategories(
     };
   } catch (error: unknown) {
     console.error("Error inesperado al obtener categorías:", error);
-    const errorMessage =
-      error instanceof Error ? error.message : "Error desconocido";
+    const errorMessage = getErrorMessage(error);
     return {
       success: false,
       errors: { form: errorMessage },
@@ -159,8 +216,7 @@ export async function createCategory(
     };
   } catch (error: unknown) {
     console.error("Error inesperado al crear categoría:", error);
-    const errorMessage =
-      error instanceof Error ? error.message : "Error desconocido";
+    const errorMessage = getErrorMessage(error);
     return {
       success: false,
       errors: { form: errorMessage },
@@ -176,24 +232,12 @@ export async function updateCategory(
   categoryId: number,
   input: CategoryUpdateInput,
 ): Promise<CategoryActionResponse> {
-  const roleCheck = await requireAdminRole();
-  if (!roleCheck.success) return roleCheck;
+  const hasName = input.nombre !== undefined;
+  const hasDescription = input.descripcion !== undefined;
 
-  try {
-    const currentCategory = await getActiveCategoryById(categoryId);
-    if (!currentCategory) {
-      return {
-        success: false,
-        errors: { form: "La categoría no existe o ya fue eliminada." },
-        message: "La categoría no existe o ya fue eliminada.",
-      };
-    }
+  const payload: CategoryUpdateInput = {};
 
-    const hasName = input.nombre !== undefined;
-    const hasDescription = input.descripcion !== undefined;
-
-    const payload: CategoryUpdateInput = {};
-
+  const mutation: MutationFn = async (currentCategory) => {
     if (hasName) {
       const nameValidationResult = await validateAndBuildNameUpdate(
         input.nombre,
@@ -210,44 +254,21 @@ export async function updateCategory(
       payload.descripcion = normalizeDescription(input.descripcion);
     }
 
-    try {
-      await updateCategoryById(categoryId, payload);
-    } catch (error) {
-      return {
-        success: false,
-        errors: { form: getErrorMessage(error) },
-        message: "No se pudo actualizar la categoría.",
-      };
-    }
+    await updateCategoryById(categoryId, payload);
+  };
 
-    const actor = await getCurrentUser();
-    if (actor) {
-      await logAdminAction({
-        actorId: actor.id,
-        action: AccionAdministrador.MODIFICAR,
-        description: `Se actualizó la categoría "${payload.nombre ?? currentCategory.nombre}".`,
-        entity: {
-          id: String(categoryId),
-          entity_type: "categoría",
-          display_name: payload.nombre ?? currentCategory.nombre,
-        },
-      });
-    }
+  const buildAuditDescription: AuditDescriptionBuilder = (category) =>
+    `Se actualizó la categoría "${payload.nombre ?? category.nombre}".`;
 
-    return {
-      success: true,
-      message: "Categoría actualizada exitosamente.",
-    };
-  } catch (error: unknown) {
-    console.error("Error inesperado al actualizar categoría:", error);
-    const errorMessage =
-      error instanceof Error ? error.message : "Error desconocido";
-    return {
-      success: false,
-      errors: { form: errorMessage },
-      message: "No se pudo actualizar la categoría.",
-    };
-  }
+  return executeAdminCategoryMutation(
+    categoryId,
+    null,
+    mutation,
+    buildAuditDescription,
+    AccionAdministrador.MODIFICAR,
+    "No se pudo actualizar la categoría.",
+    "Categoría actualizada exitosamente.",
+  );
 }
 
 /**
@@ -256,19 +277,7 @@ export async function updateCategory(
 export async function deleteCategory(
   categoryId: number,
 ): Promise<CategoryActionResponse> {
-  const roleCheck = await requireAdminRole();
-  if (!roleCheck.success) return roleCheck;
-
-  try {
-    const currentCategory = await getActiveCategoryById(categoryId);
-    if (!currentCategory) {
-      return {
-        success: false,
-        errors: { form: "La categoría no existe o ya fue eliminada." },
-        message: "La categoría no existe o ya fue eliminada.",
-      };
-    }
-
+  const preMutationValidator: PreMutationValidator = async () => {
     const hasLinkedBooks = await hasActiveBooksForCategory(categoryId);
     if (hasLinkedBooks) {
       return {
@@ -280,43 +289,23 @@ export async function deleteCategory(
           "No se puede eliminar la categoría porque tiene libros asociados.",
       };
     }
+    return null;
+  };
 
-    try {
-      await softDeleteCategoryById(categoryId);
-    } catch (error) {
-      return {
-        success: false,
-        errors: { form: getErrorMessage(error) },
-        message: "No se pudo eliminar la categoría.",
-      };
-    }
+  const mutation: MutationFn = async () => {
+    await softDeleteCategoryById(categoryId);
+  };
 
-    const actor = await getCurrentUser();
-    if (actor) {
-      await logAdminAction({
-        actorId: actor.id,
-        action: AccionAdministrador.ELIMINAR,
-        description: `Se eliminó la categoría "${currentCategory.nombre}".`,
-        entity: {
-          id: String(categoryId),
-          entity_type: "categoría",
-          display_name: currentCategory.nombre,
-        },
-      });
-    }
+  const buildAuditDescription: AuditDescriptionBuilder = (category) =>
+    `Se eliminó la categoría "${category.nombre}".`;
 
-    return {
-      success: true,
-      message: "Categoría eliminada exitosamente.",
-    };
-  } catch (error: unknown) {
-    console.error("Error inesperado al eliminar categoría:", error);
-    const errorMessage =
-      error instanceof Error ? error.message : "Error desconocido";
-    return {
-      success: false,
-      errors: { form: errorMessage },
-      message: "No se pudo eliminar la categoría.",
-    };
-  }
+  return executeAdminCategoryMutation(
+    categoryId,
+    preMutationValidator,
+    mutation,
+    buildAuditDescription,
+    AccionAdministrador.ELIMINAR,
+    "No se pudo eliminar la categoría.",
+    "Categoría eliminada exitosamente.",
+  );
 }

--- a/services/copia/copiaService.ts
+++ b/services/copia/copiaService.ts
@@ -42,6 +42,7 @@ import type {
   InventarioOptionsResponse,
   VistaInventarioRow,
 } from "@/lib/types/inventario";
+import type { TiendaRead } from "@/lib/types/tienda";
 import type { EstadoHistorico } from "@/lib/types/historico";
 
 import { requireAdminRole } from "@/lib/validations/server-auth";
@@ -420,84 +421,63 @@ export async function transferCopiasByQuantity(
 
   const safeQuantity = Math.max(1, input.cantidad);
 
+  const entityValidation = await validateTransferEntities(input);
+  if (!entityValidation.success && entityValidation.response) {
+    return entityValidation.response;
+  }
+
+  const availableCopies = await getAvailableCopiasByLibroAndStore(
+    input.id_libro,
+    input.id_tienda_origen,
+  );
+
+  if (availableCopies === null) {
+    return {
+      success: false,
+      errors: {
+        form: "No se pudo verificar el stock disponible en la tienda de origen.",
+      },
+      message:
+        "No se pudo verificar el stock disponible en la tienda de origen.",
+    };
+  }
+
+  const stockError = checkStockSufficiency(availableCopies ?? 0, safeQuantity);
+  if (stockError) return stockError;
+
+  let transferredIds: string[];
   try {
-    const originStore = await getActiveTiendaById(input.id_tienda_origen);
-    const destinationStore = await getActiveTiendaById(input.id_tienda_destino);
-    const libro = await getActiveLibroById(input.id_libro);
-    const entityValidation = validateTransferCopiasByQuantityEntities({
-      originStore,
-      destinationStore,
-      libroExists: Boolean(libro),
+    transferredIds = await transferCopiasByQuantityAtomic({
+      id_tienda_origen: input.id_tienda_origen,
+      id_tienda_destino: input.id_tienda_destino,
+      id_libro: input.id_libro,
+      cantidad: safeQuantity,
     });
-    if (!entityValidation.success) return entityValidation.response;
-
-    const availableCopies = await getAvailableCopiasByLibroAndStore(
-      input.id_libro,
-      input.id_tienda_origen,
-    );
-
-    if (availableCopies === null) {
-      return {
-        success: false,
-        errors: {
-          form: "No se pudo verificar el stock disponible en la tienda de origen.",
-        },
-        message:
-          "No se pudo verificar el stock disponible en la tienda de origen.",
-      };
-    }
-
-    const stockValidationError = getTransferCopiasByQuantityStockError({
-      availableCount: availableCopies ?? 0,
-      requestedQuantity: safeQuantity,
-    });
-
-    if (stockValidationError) return stockValidationError;
-
-    let transferredIds: string[];
-    try {
-      transferredIds = await transferCopiasByQuantityAtomic({
-        id_tienda_origen: input.id_tienda_origen,
-        id_tienda_destino: input.id_tienda_destino,
-        id_libro: input.id_libro,
-        cantidad: safeQuantity,
-      });
-    } catch (error) {
-      if (error instanceof InsufficientStockError) {
-        return {
-          success: false,
-          errors: { form: getErrorMessage(error) },
-          transferredIds: error.transferredIds,
-          errorCode: error.errorCode,
-        } as CopiaActionResponse;
-      }
+  } catch (error) {
+    if (error instanceof InsufficientStockError) {
       return {
         success: false,
         errors: { form: getErrorMessage(error) },
-        message: "No se pudo trasladar el inventario por cantidad.",
-      };
+        transferredIds: error.transferredIds,
+        errorCode: error.errorCode,
+      } as CopiaActionResponse;
     }
-
-    await logTransferCopiasAudit(
-      transferredIds,
-      entityValidation.destinationStore,
-    );
-
-    return {
-      success: true,
-      message: buildTransferCopiasByQuantitySuccessMessage(safeQuantity),
-    };
-  } catch (error: unknown) {
-    console.error(
-      "[copiaServices] Error inesperado al trasladar inventario por cantidad:",
-      error,
-    );
     return {
       success: false,
       errors: { form: getErrorMessage(error) },
       message: "No se pudo trasladar el inventario por cantidad.",
     };
   }
+
+  await logTransferCopiasAudit(
+    transferredIds,
+    entityValidation.destinationStore!,
+  );
+
+  return {
+    success: true,
+    message: buildTransferCopiasByQuantitySuccessMessage(safeQuantity),
+  };
 }
 
 /**
@@ -839,4 +819,38 @@ async function getInfos(copiaIds: string[]): Promise<CopiaRow[]> {
 
 function getTiendasSet(copiasInfo: CopiaRow[]): Set<string> {
   return new Set(copiasInfo.map((copy) => copy.id_tienda));
+}
+
+interface TransferEntitiesValidation {
+  success: boolean;
+  response?: CopiaActionResponse;
+  destinationStore?: TiendaRead | null;
+}
+
+async function validateTransferEntities(
+  input: TransferCopiasByQuantityInput,
+): Promise<TransferEntitiesValidation> {
+  const originStore = await getActiveTiendaById(input.id_tienda_origen);
+  const destinationStore = await getActiveTiendaById(input.id_tienda_destino);
+  const libro = await getActiveLibroById(input.id_libro);
+  const entityValidation = validateTransferCopiasByQuantityEntities({
+    originStore,
+    destinationStore,
+    libroExists: Boolean(libro),
+  });
+  if (!entityValidation.success) {
+    return { success: false, response: entityValidation.response };
+  }
+  return { success: true, destinationStore };
+}
+
+function checkStockSufficiency(
+  availableCount: number,
+  safeQuantity: number,
+): CopiaActionResponse | null {
+  const stockValidationError = getTransferCopiasByQuantityStockError({
+    availableCount,
+    requestedQuantity: safeQuantity,
+  });
+  return stockValidationError;
 }

--- a/services/copia/copiaService.ts
+++ b/services/copia/copiaService.ts
@@ -8,6 +8,7 @@ import {
   softDeleteCopias,
   transferCopias as transferCopiasModel,
   transferCopiasByQuantityAtomic,
+  InsufficientStockError,
 } from "@/models/copiaModel";
 import {
   getHistoricoSyncSnapshotsByLibros,
@@ -44,10 +45,9 @@ import type {
 import type { EstadoHistorico } from "@/lib/types/historico";
 
 import { requireAdminRole } from "@/lib/validations/server-auth";
-import { isValidUUID, MAX_PAGE_SIZE } from "@/lib/validations/rules";
+import { MAX_PAGE_SIZE } from "@/lib/validations/rules";
 import {
   buildTransferCopiasByQuantitySuccessMessage,
-  getTransferCopiasByQuantityModelError,
   getTransferCopiasByQuantityStockError,
   validateTransferCopiasByQuantityEntities,
 } from "@/services/rules/copiaRules";
@@ -62,14 +62,6 @@ function toUniqueIds(ids: OneOrManyCopyIds): string[] {
 
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "Error desconocido";
-}
-
-function getMissingCopyIds(
-  requestedIds: string[],
-  foundCopies: CopiaRow[],
-): string[] {
-  const foundIds = new Set(foundCopies.map((copy) => copy.id));
-  return requestedIds.filter((copyId) => !foundIds.has(copyId));
 }
 
 function aggregateInventarioRows(
@@ -182,10 +174,11 @@ async function syncHistoricoForBooks(libroIds: string[]): Promise<void> {
 
   if (historicoRows.length === 0) return;
 
-  const historicoResult = await insertHistoricoBatch(historicoRows);
-  if (!historicoResult.success) {
+  try {
+    await insertHistoricoBatch(historicoRows);
+  } catch (error) {
     console.error(
-      historicoResult.error ??
+      getErrorMessage(error) ??
         "No se pudo registrar la sincronización del histórico de stock para los libros indicados.",
       {
         libroIds: historicoRows.map((row) => row.id_libro),
@@ -301,14 +294,15 @@ export async function createCopias(
       estado: input.estado,
     }));
 
-    const result = await insertCopias(copiesToInsert);
-    if (!result.success) {
+    try {
+      await insertCopias(copiesToInsert);
+    } catch (error) {
       return {
         success: false,
         errors: {
-          form: result.error ?? "No se pudieron crear las copias.",
+          form: getErrorMessage(error),
         },
-        message: result.error ?? "No se pudieron crear las copias.",
+        message: getErrorMessage(error),
       };
     }
 
@@ -382,14 +376,15 @@ export async function transferCopias(
       };
     }
 
-    const result = await transferCopiasModel(copyIds, input.id_tienda);
-    if (!result.success) {
+    try {
+      await transferCopiasModel(copyIds, input.id_tienda);
+    } catch (error) {
       return {
         success: false,
         errors: {
-          form: result.error ?? "No se pudieron trasladar las copias.",
+          form: getErrorMessage(error),
         },
-        message: result.error ?? "No se pudieron trasladar las copias.",
+        message: getErrorMessage(error),
       };
     }
 
@@ -459,18 +454,30 @@ export async function transferCopiasByQuantity(
 
     if (stockValidationError) return stockValidationError;
 
-    const transferResult = await transferCopiasByQuantityAtomic({
-      id_tienda_origen: input.id_tienda_origen,
-      id_tienda_destino: input.id_tienda_destino,
-      id_libro: input.id_libro,
-      cantidad: safeQuantity,
-    });
+    let transferredIds: string[];
+    try {
+      transferredIds = await transferCopiasByQuantityAtomic({
+        id_tienda_origen: input.id_tienda_origen,
+        id_tienda_destino: input.id_tienda_destino,
+        id_libro: input.id_libro,
+        cantidad: safeQuantity,
+      });
+    } catch (error) {
+      if (error instanceof InsufficientStockError) {
+        return {
+          success: false,
+          errors: { form: getErrorMessage(error) },
+          transferredIds: error.transferredIds,
+          errorCode: error.errorCode,
+        } as CopiaActionResponse;
+      }
+      return {
+        success: false,
+        errors: { form: getErrorMessage(error) },
+        message: "No se pudo trasladar el inventario por cantidad.",
+      };
+    }
 
-    const transferError = getTransferCopiasByQuantityModelError(transferResult);
-
-    if (transferError) return transferError;
-
-    const transferredIds = transferResult.transferredIds ?? [];
     await logTransferCopiasAudit(
       transferredIds,
       entityValidation.destinationStore,
@@ -539,13 +546,13 @@ export async function deleteCopias(
     }
 
     // c. eliminación lógica en una operación de modelo
-    const result = await softDeleteCopias(copyIds);
-
-    if (!result.success) {
+    try {
+      await softDeleteCopias(copyIds);
+    } catch (error) {
       return {
         success: false,
-        errors: { form: result.error ?? "No se pudieron eliminar las copias." },
-        message: result.error ?? "No se pudieron eliminar las copias.",
+        errors: { form: getErrorMessage(error) },
+        message: getErrorMessage(error),
       };
     }
 

--- a/services/libros/libroService.ts
+++ b/services/libros/libroService.ts
@@ -1,3 +1,4 @@
+import { getErrorMessage } from "@/lib/services/errors";
 import { requireAdminRole } from "@/lib/validations/server-auth";
 import {
   checkLibroDuplicateInfo,
@@ -42,55 +43,53 @@ export async function createBook(
   const roleCheck = await requireAdminRole();
   if (!roleCheck.success) return roleCheck;
 
+  let isDuplicate: boolean;
   try {
-    const isDuplicate = await checkLibroDuplicateInfo(
+    isDuplicate = await checkLibroDuplicateInfo(
       data.titulo,
       data.isbn,
       data.estado
     );
-    if (isDuplicate) {
-      return {
-        success: false,
-        errors: { form: "Ya existe un libro con este título, ISBN y estado." },
-        message: "El libro ya está registrado.",
-      };
-    }
-  } catch (_) {
+  } catch (error) {
     return {
       success: false,
-      message: "Error al verificar la existencia del libro.",
+      message: `Error al verificar la existencia del libro: ${getErrorMessage(error)}`,
+    };
+  }
+  if (isDuplicate) {
+    return {
+      success: false,
+      errors: { form: "Ya existe un libro con este título, ISBN y estado." },
+      message: "El libro ya está registrado.",
     };
   }
 
-  const resultLibro = await createLibro(data);
-  if (!resultLibro.success || !resultLibro.id) {
+  let libroId: string;
+  try {
+    libroId = await createLibro(data);
+  } catch (error) {
     return {
       success: false,
-      message: resultLibro.error || "Error al crear el libro principal.",
+      message: getErrorMessage(error),
     };
   }
-
-  const libroId = String(resultLibro.id);
 
   try {
-    // Calcular fechas
     const now = new Date();
     const expiracion = new Date(now.getTime() + 8 * 24 * 60 * 60 * 1000);
 
-    const noticiaResult = await insertNoticia({
+    await insertNoticia({
       id_libro: libroId,
       fecha_publicacion: now.toISOString(),
       fecha_expiracion: expiracion.toISOString(),
       es_visible: true,
     });
-    if (!noticiaResult.success) throw new Error(noticiaResult.error);
 
-    const historicoResult = await insertHistorico({
+    await insertHistorico({
       id_libro: libroId,
       estado: "agotado",
       fecha: now.toISOString(),
     });
-    if (!historicoResult.success) throw new Error(historicoResult.error);
 
     const actor = await getCurrentUser();
     if (actor) {
@@ -108,7 +107,7 @@ export async function createBook(
     await rollbackLibro(libroId);
     return {
       success: false,
-      message: "Ocurrió un error al registrar las dependencias del libro. Se ha cancelado la operación.",
+      message: `Ocurrió un error al registrar las dependencias del libro: ${getErrorMessage(err)}. Se ha cancelado la operación.`,
     };
   }
 }
@@ -124,38 +123,38 @@ export async function createBookWithInventory(
   const roleCheck = await requireAdminRole();
   if (!roleCheck.success) return roleCheck;
 
+  let isDuplicate: boolean;
   try {
-    const isDuplicate = await checkLibroDuplicateInfo(
+    isDuplicate = await checkLibroDuplicateInfo(
       data.titulo,
       data.isbn,
       data.estado
     );
-    if (isDuplicate) {
-      return {
-        success: false,
-        errors: { form: "Ya existe un libro con este título, ISBN y estado." },
-        message: "El libro ya está registrado.",
-      };
-    }
-  } catch (_) {
+  } catch (error) {
     return {
       success: false,
-      message: "Error al verificar la existencia del libro.",
+      message: `Error al verificar la existencia del libro: ${getErrorMessage(error)}`,
+    };
+  }
+  if (isDuplicate) {
+    return {
+      success: false,
+      errors: { form: "Ya existe un libro con este título, ISBN y estado." },
+      message: "El libro ya está registrado.",
     };
   }
 
-  const resultLibro = await createLibro(data);
-  if (!resultLibro.success || !resultLibro.id) {
+  let libroId: string;
+  try {
+    libroId = await createLibro(data);
+  } catch (error) {
     return {
       success: false,
-      message: resultLibro.error || "Error al crear el libro principal.",
+      message: getErrorMessage(error),
     };
   }
-
-  const libroId = String(resultLibro.id);
 
   try {
-    // 1. Insertar copias
     const copiasResult = await createCopias({
       id_libro: libroId,
       estado: "disponible",
@@ -164,17 +163,15 @@ export async function createBookWithInventory(
     });
     if (!copiasResult.success) throw new Error(copiasResult.message || "Error insertando copias");
 
-    // 2. Fechas para noticia e histórico
     const now = new Date();
     const expiracion = new Date(now.getTime() + 8 * 24 * 60 * 60 * 1000);
 
-    const noticiaResult = await insertNoticia({
+    await insertNoticia({
       id_libro: libroId,
       fecha_publicacion: now.toISOString(),
       fecha_expiracion: expiracion.toISOString(),
       es_visible: true,
     });
-    if (!noticiaResult.success) throw new Error(noticiaResult.error);
 
     const actor = await getCurrentUser();
     if (actor) {
@@ -192,7 +189,7 @@ export async function createBookWithInventory(
     await rollbackLibro(libroId);
     return {
       success: false,
-      message: "Ocurrió un error al registrar las dependencias o el inventario del libro. Se ha cancelado la operación.",
+      message: `Ocurrió un error al registrar las dependencias o el inventario del libro: ${getErrorMessage(err)}. Se ha cancelado la operación.`,
     };
   }
 }
@@ -233,16 +230,16 @@ export async function editBook(
   } catch (error) {
     return {
       success: false,
-      message: "Error al verificar la existencia del libro.",
+      message: `Error al verificar la existencia del libro: ${getErrorMessage(error)}`,
     };
   }
 
-  const result = await updateLibroById(id, data);
-
-  if (!result.success) {
+  try {
+    await updateLibroById(id, data);
+  } catch (error) {
     return {
       success: false,
-      message: result.error || "Error al actualizar el libro.",
+      message: getErrorMessage(error),
     };
   }
 
@@ -264,8 +261,7 @@ export async function editBook(
  */
 export async function removeBook(
   id: string,
-  titulo: string,
-  _estado: string
+  titulo: string
 ): Promise<LibroActionResponse> {
   const roleCheck = await requireAdminRole();
   if (!roleCheck.success) return roleCheck;
@@ -278,23 +274,22 @@ export async function removeBook(
         message: `No se puede eliminar el libro porque tiene ${copiasCount} copia(s) asociada(s).`,
       };
     }
-  } catch (_) {
+  } catch {
     return {
       success: false,
       message: "Error al verificar las copias asociadas al libro.",
     };
   }
 
-  const result = await softDeleteLibroById(id);
-
-  if (!result.success) {
+  try {
+    await softDeleteLibroById(id);
+  } catch (error) {
     return {
       success: false,
-      message: result.error || "Error al eliminar el libro.",
+      message: getErrorMessage(error),
     };
   }
 
-  // Borrado en cascada orquestado por el servicio
   await softDeleteNoticiaByLibroId(id);
   await deleteHistoricoByLibroId(id);
 

--- a/services/modelo-ra/modeloRAService.ts
+++ b/services/modelo-ra/modeloRAService.ts
@@ -12,6 +12,7 @@ import type {
 } from "@/lib/types/modelo_ra";
 import { requireAdminRole } from "@/lib/validations/server-auth";
 import { isValidPositiveInteger } from "@/lib/validations/rules";
+import { getErrorMessage } from "@/lib/services/errors";
 import {
   validateModeloRACreate,
   validateModeloRAUpdate,
@@ -74,11 +75,12 @@ export async function createModeloRA(
     return { success: false, errors };
   }
 
-  const result = await createModeloRAModel(input);
-  if (!result.success) {
+  try {
+    await createModeloRAModel(input);
+  } catch (error) {
     return {
       success: false,
-      errors: { form: result.error ?? "No se pudo crear el modelo RA." },
+      errors: { form: getErrorMessage(error) },
       message: "No se pudo crear el modelo RA.",
     };
   }
@@ -108,11 +110,12 @@ export async function updateModeloRA(
     return { success: false, errors };
   }
 
-  const result = await updateModeloRAById(modeloRAId, input);
-  if (!result.success) {
+  try {
+    await updateModeloRAById(modeloRAId, input);
+  } catch (error) {
     return {
       success: false,
-      errors: { form: result.error ?? "No se pudo actualizar el modelo RA." },
+      errors: { form: getErrorMessage(error) },
       message: "No se pudo actualizar el modelo RA.",
     };
   }
@@ -136,11 +139,12 @@ export async function deleteModeloRA(
     return getInvalidIdResponse();
   }
 
-  const result = await softDeleteModeloRAById(modeloRAId);
-  if (!result.success) {
+  try {
+    await softDeleteModeloRAById(modeloRAId);
+  } catch (error) {
     return {
       success: false,
-      errors: { form: result.error ?? "No se pudo eliminar el modelo RA." },
+      errors: { form: getErrorMessage(error) },
       message: "No se pudo eliminar el modelo RA.",
     };
   }

--- a/services/preferencias/preferenciasService.ts
+++ b/services/preferencias/preferenciasService.ts
@@ -1,5 +1,6 @@
 import { requireClientRole } from "@/lib/validations/server-auth";
 import { getCurrentUser } from "@/models/authModel";
+import { getErrorMessage } from "@/lib/services/errors";
 import {
   insertAuthorPreference,
   deleteAuthorPreference,
@@ -13,6 +14,7 @@ import type {
   AddAuthorPreferenceInput,
   AuthorPreferenceActionResponse,
   AuthorPreferenceDataResponse,
+  AuthorPreferenceWithDetails,
 } from "@/lib/types/authorPreference";
 
 export async function addAuthorPreference(
@@ -32,13 +34,14 @@ export async function addAuthorPreference(
   const precheckAuthor = await checkPreferenceAuthorExists(data.id_autor);
   if (precheckAuthor) return precheckAuthor;
 
-  const result = await insertAuthorPreference({ id_usuario: user.id, id_autor: data.id_autor });
-
-  if (!result.success) {
-    return { success: false, errors: { form: result.error ?? "Error de base de datos." }, message: result.error };
+  let insertedId: number;
+  try {
+    insertedId = await insertAuthorPreference({ id_usuario: user.id, id_autor: data.id_autor });
+  } catch (error) {
+    return { success: false, errors: { form: getErrorMessage(error) }, message: getErrorMessage(error) };
   }
 
-  return { success: true, id: result.id };
+  return { success: true, id: insertedId };
 }
 
 export async function removeAuthorPreference(
@@ -52,10 +55,10 @@ export async function removeAuthorPreference(
     return { success: false, errors: { form: "No hay sesión activa." }, message: "No hay sesión activa." };
   }
 
-  const result = await deleteAuthorPreference(user.id, id_autor);
-
-  if (!result.success) {
-    return { success: false, errors: { form: result.error ?? "Error de base de datos." }, message: result.error };
+  try {
+    await deleteAuthorPreference(user.id, id_autor);
+  } catch (error) {
+    return { success: false, errors: { form: getErrorMessage(error) }, message: getErrorMessage(error) };
   }
 
   return { success: true };
@@ -70,9 +73,12 @@ export async function getMyAuthorPreferences(): Promise<AuthorPreferenceDataResp
     return { success: false, errors: { form: "No hay sesión activa." } };
   }
 
-  const result = await getAuthorPreferencesByUser(user.id);
-  if (!result.success) {
-    return { success: false, errors: { form: result.error ?? "Error desconocido" }, message: result.error };
+  let preferences: AuthorPreferenceWithDetails[];
+  try {
+    preferences = await getAuthorPreferencesByUser(user.id);
+  } catch (error) {
+    return { success: false, errors: { form: getErrorMessage(error) }, message: getErrorMessage(error) };
   }
-  return { success: true, data: result.data };
+
+  return { success: true, data: preferences };
 }

--- a/services/profile/completeProfileService.ts
+++ b/services/profile/completeProfileService.ts
@@ -7,6 +7,7 @@ import {
 } from "@/models/userModel";
 import { createAddress, deleteAddress } from "@/models/addressModel";
 import { createAdminClient, createClient } from "@/lib/supabase/server";
+import { getErrorMessage } from "@/lib/services/errors";
 import type { PersonalData, Genero } from "@/lib/types/auth";
 import type { ProfileUpdateResponse, FullProfilePayload } from "@/lib/types/profile";
 
@@ -45,7 +46,15 @@ export async function completeAdminProfile(
     userId = user.id;
 
     // 1. Validar unicidad de DNI
-    const dniExists = await checkDniExists(input.dni);
+    let dniExists: boolean;
+    try {
+      dniExists = await checkDniExists(input.dni);
+    } catch (error) {
+      return {
+        success: false,
+        errors: { form: `Error verificando DNI: ${getErrorMessage(error)}` },
+      };
+    }
     if (dniExists) {
       return {
         success: false,
@@ -54,14 +63,16 @@ export async function completeAdminProfile(
     }
 
     // 2. Validar unicidad de username
-    const usernameCheck = await checkUsernameExists(input.usuario);
-    if (usernameCheck.error) {
+    let usernameExists: boolean;
+    try {
+      usernameExists = await checkUsernameExists(input.usuario);
+    } catch (error) {
       return {
         success: false,
-        errors: { form: `Error verificando usuario: ${usernameCheck.error}` },
+        errors: { form: `Error verificando usuario: ${getErrorMessage(error)}` },
       };
     }
-    if (usernameCheck.exists) {
+    if (usernameExists) {
       return {
         success: false,
         errors: { usuario: "El usuario o documento de identidad ya ha sido registrado en otra cuenta. Por favor pruebe con otro." },
@@ -71,19 +82,20 @@ export async function completeAdminProfile(
     // 3. (Movido al final) La contraseña se actualiza de último para asegurar rollback completo.
 
     // 4. Crear dirección
-    const addressResult = await createAddress({
-      direccion: input.direccion,
-      placeId: input.direccion_place_id,
-      detalle: input.direccion_detalle ?? undefined,
-    });
-
-    if (!addressResult.success || !addressResult.id) {
+    let addressId: number;
+    try {
+      addressId = await createAddress({
+        direccion: input.direccion,
+        placeId: input.direccion_place_id,
+        detalle: input.direccion_detalle ?? undefined,
+      });
+    } catch (error) {
       return {
         success: false,
-        errors: { direccion: `Error al registrar dirección: ${addressResult.error}` },
+        errors: { direccion: `Error al registrar dirección: ${getErrorMessage(error)}` },
       };
     }
-    createdAddressId = addressResult.id;
+    createdAddressId = addressId;
 
     // 5. Crear perfil de usuario
     const personalData: PersonalData = {
@@ -99,21 +111,16 @@ export async function completeAdminProfile(
       usuario: input.usuario,
     };
 
-    const profileResult = await createUserProfile(
-      userId,
-      personalData,
-      addressResult.id
-    );
-
-    if (!profileResult.success) {
-      // Rollback: eliminar dirección creada
+    try {
+      await createUserProfile(userId, personalData, addressId);
+      profileCreated = true;
+    } catch (error) {
       if (createdAddressId) await deleteAddress(createdAddressId);
       return {
         success: false,
-        errors: { form: `Error al crear perfil: ${profileResult.error}` },
+        errors: { form: `Error al crear perfil: ${getErrorMessage(error)}` },
       };
     }
-    profileCreated = true;
 
     // 6. Marcar profile_complete en app_metadata + actualizar username
     const adminClient = createAdminClient();

--- a/services/profile/completeProfileService.ts
+++ b/services/profile/completeProfileService.ts
@@ -11,6 +11,57 @@ import { getErrorMessage } from "@/lib/services/errors";
 import type { PersonalData, Genero } from "@/lib/types/auth";
 import type { ProfileUpdateResponse, FullProfilePayload } from "@/lib/types/profile";
 
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+interface UserMetadata {
+  appMeta: Record<string, unknown>;
+  userMeta: Record<string, unknown>;
+}
+
+async function rollbackProfileCreation(
+  userId: string | null,
+  addressId: number | null,
+  profileCreated: boolean,
+): Promise<void> {
+  if (profileCreated && userId) {
+    await deleteUserProfile(userId).catch((e) =>
+      console.error("Rollback profile error:", e),
+    );
+  }
+  if (addressId) {
+    await deleteAddress(addressId).catch((e) =>
+      console.error("Rollback address error:", e),
+    );
+  }
+}
+
+async function getUserMetadataSafe(
+  userId: string,
+  adminClient: ReturnType<typeof createAdminClient>,
+): Promise<UserMetadata> {
+  const { data, error } = await adminClient.auth.admin.getUserById(userId);
+  if (error) return { appMeta: {}, userMeta: {} };
+  return {
+    appMeta:
+      data?.user?.app_metadata && typeof data.user.app_metadata === "object"
+        ? data.user.app_metadata
+        : {},
+    userMeta:
+      data?.user?.user_metadata && typeof data.user.user_metadata === "object"
+        ? data.user.user_metadata
+        : {},
+  };
+}
+
+async function updateUserPassword(
+  userId: string,
+  password: string,
+): Promise<string | null> {
+  const supabase = await createClient();
+  const { error } = await supabase.auth.updateUser({ password });
+  return error ? error.message : null;
+}
+
 // ─── Tipos ─────────────────────────────────────────────────────────
 
 interface CompleteAdminProfileInput extends FullProfilePayload {
@@ -45,16 +96,7 @@ export async function completeAdminProfile(
     }
     userId = user.id;
 
-    // 1. Validar unicidad de DNI
-    let dniExists: boolean;
-    try {
-      dniExists = await checkDniExists(input.dni);
-    } catch (error) {
-      return {
-        success: false,
-        errors: { form: `Error verificando DNI: ${getErrorMessage(error)}` },
-      };
-    }
+    const dniExists = await checkDniExists(input.dni);
     if (dniExists) {
       return {
         success: false,
@@ -62,16 +104,7 @@ export async function completeAdminProfile(
       };
     }
 
-    // 2. Validar unicidad de username
-    let usernameExists: boolean;
-    try {
-      usernameExists = await checkUsernameExists(input.usuario);
-    } catch (error) {
-      return {
-        success: false,
-        errors: { form: `Error verificando usuario: ${getErrorMessage(error)}` },
-      };
-    }
+    const usernameExists = await checkUsernameExists(input.usuario);
     if (usernameExists) {
       return {
         success: false,
@@ -79,9 +112,6 @@ export async function completeAdminProfile(
       };
     }
 
-    // 3. (Movido al final) La contraseña se actualiza de último para asegurar rollback completo.
-
-    // 4. Crear dirección
     let addressId: number;
     try {
       addressId = await createAddress({
@@ -97,7 +127,6 @@ export async function completeAdminProfile(
     }
     createdAddressId = addressId;
 
-    // 5. Crear perfil de usuario
     const personalData: PersonalData = {
       dni: input.dni,
       nombres: input.nombres,
@@ -115,64 +144,28 @@ export async function completeAdminProfile(
       await createUserProfile(userId, personalData, addressId);
       profileCreated = true;
     } catch (error) {
-      if (createdAddressId) await deleteAddress(createdAddressId);
+      await rollbackProfileCreation(userId, createdAddressId, profileCreated);
       return {
         success: false,
         errors: { form: `Error al crear perfil: ${getErrorMessage(error)}` },
       };
     }
 
-    // 6. Marcar profile_complete en app_metadata + actualizar username
     const adminClient = createAdminClient();
+    const { appMeta: existingAppMetadata, userMeta: existingUserMetadata } =
+      await getUserMetadataSafe(userId, adminClient);
 
-    // Obtener metadata actual para no perder claves críticas (p.ej. role)
-    const { data: userData, error: fetchUserError } =
-      await adminClient.auth.admin.getUserById(userId);
-
-    if (fetchUserError) {
-      console.error("Error al obtener app_metadata actual:", fetchUserError);
-    }
-
-    const existingAppMetadata =
-      userData?.user?.app_metadata && typeof userData.user.app_metadata === "object"
-        ? userData.user.app_metadata
-        : {};
-
-    const existingUserMetadata =
-      userData?.user?.user_metadata && typeof userData.user.user_metadata === "object"
-        ? userData.user.user_metadata
-        : {};
-
-    const updatedAppMetadata = {
-      ...existingAppMetadata,
-      profile_complete: true,
-    };
-
-    const updatedUserMetadata = {
-      ...existingUserMetadata,
-      username: input.usuario,
-    };
+    const updatedAppMetadata = { ...existingAppMetadata, profile_complete: true };
+    const updatedUserMetadata = { ...existingUserMetadata, username: input.usuario };
 
     const { error: metaError } = await adminClient.auth.admin.updateUserById(
       userId,
-      {
-        app_metadata: updatedAppMetadata,
-        user_metadata: updatedUserMetadata,
-      }
+      { app_metadata: updatedAppMetadata, user_metadata: updatedUserMetadata }
     );
+
     if (metaError) {
       console.error("Error al marcar profile_complete:", metaError);
-      
-      // Rollback: deshacer perfil y dirección
-      if (profileCreated && userId) {
-        await deleteUserProfile(userId);
-      }
-      if (createdAddressId) {
-        await deleteAddress(createdAddressId);
-      }
-
-      // Este paso es crítico para que el middleware permita el acceso.
-      // Si falla, consideramos que el flujo no se completó correctamente.
+      await rollbackProfileCreation(userId, createdAddressId, profileCreated);
       const metaErrorMessage =
         metaError instanceof Error ? metaError.message : "Error al actualizar metadatos de usuario.";
       return {
@@ -183,16 +176,10 @@ export async function completeAdminProfile(
       };
     }
 
-    // 7. Actualizar contraseña (paso final, asegura que se mantiene la anterior si hay fallo)
-    const supabase = await createClient();
-    const { error: pwdError } = await supabase.auth.updateUser({
-      password: input.nueva_contrasena,
-    });
+    const pwdError = await updateUserPassword(userId, input.nueva_contrasena);
 
     if (pwdError) {
       console.error("Error al actualizar contraseña:", pwdError);
-      
-      // Rollback: revertir app_metadata y user_metadata a su estado original
       try {
         await adminClient.auth.admin.updateUserById(userId, {
           app_metadata: existingAppMetadata,
@@ -201,42 +188,18 @@ export async function completeAdminProfile(
       } catch (err) {
         console.error("Error crítico al revertir metadatos:", err);
       }
-
-      // Rollback: deshacer perfil y dirección
-      if (profileCreated && userId) {
-        await deleteUserProfile(userId);
-      }
-      if (createdAddressId) {
-        await deleteAddress(createdAddressId);
-      }
-
+      await rollbackProfileCreation(userId, createdAddressId, profileCreated);
       return {
         success: false,
         errors: { form: "No se pudo actualizar la contraseña. Revisa que sea segura e intenta de nuevo." },
       };
     }
 
-    return {
-      success: true,
-      message: "Perfil configurado exitosamente.",
-    };
+    return { success: true, message: "Perfil configurado exitosamente." };
   } catch (error: unknown) {
     console.error("Error inesperado en completeAdminProfile:", error);
-
-    // Rollback genérico si ocurre una excepción
-    try {
-      if (profileCreated && userId) {
-        await deleteUserProfile(userId);
-      }
-      if (createdAddressId) {
-        await deleteAddress(createdAddressId);
-      }
-    } catch (rollbackError) {
-      console.error("Error durante rollback en el catch:", rollbackError);
-    }
-
-    const errorMessage =
-      error instanceof Error ? error.message : "Desconocido";
+    await rollbackProfileCreation(userId, createdAddressId, profileCreated);
+    const errorMessage = error instanceof Error ? error.message : "Desconocido";
     return {
       success: false,
       errors: { form: `Error inesperado: ${errorMessage}` },

--- a/services/profile/profileService.ts
+++ b/services/profile/profileService.ts
@@ -14,6 +14,7 @@ import type {
   ProfileUpdatePayload,
   ProfileUpdateResponse,
 } from "@/lib/types/profile";
+import { getErrorMessage } from "@/lib/services/errors";
 
 // ─── Lectura del perfil ────────────────────────────────────────────
 
@@ -81,16 +82,18 @@ export async function updateProfile(
 
     // 1. Verificar unicidad del username si cambió
     if (payload.usuario !== currentUsername) {
-      const usernameCheck = await checkUsernameExists(payload.usuario);
-      if (usernameCheck.error) {
+      let usernameExists: boolean;
+      try {
+        usernameExists = await checkUsernameExists(payload.usuario);
+      } catch (error) {
         return {
           success: false,
           errors: {
-            form: `Error verificando usuario: ${usernameCheck.error}`,
+            form: `Error verificando usuario: ${getErrorMessage(error)}`,
           },
         };
       }
-      if (usernameCheck.exists) {
+      if (usernameExists) {
         return {
           success: false,
           errors: { usuario: "El nombre de usuario ya está en uso." },
@@ -100,38 +103,38 @@ export async function updateProfile(
 
     // 2. Crear nueva dirección (Inmutabilidad: siempre se crea nueva)
     // No editamos la anterior para mantener integridad histórica de entregas/tiendas.
-    const createResult = await createAddress({
-      direccion: payload.direccion,
-      placeId: payload.direccion_place_id,
-      detalle: payload.direccion_detalle ?? undefined,
-    });
-
-    if (!createResult.success) {
+    let newAddressId: number;
+    try {
+      newAddressId = await createAddress({
+        direccion: payload.direccion,
+        placeId: payload.direccion_place_id,
+        detalle: payload.direccion_detalle ?? undefined,
+      });
+    } catch (error) {
       return {
         success: false,
         errors: {
-          direccion: `Error al crear nueva dirección: ${createResult.error}`,
+          direccion: `Error al crear nueva dirección: ${getErrorMessage(error)}`,
         },
       };
     }
-    const newAddressId = createResult.id!;
 
     // 3. Actualizar perfil de usuario con la nueva dirección
-    const profileResult = await updateUserProfile(userId, {
-      nombres: payload.nombres,
-      apellidos: payload.apellidos,
-      genero: payload.genero,
-      id_direccion: newAddressId,
-    });
-
-    if (!profileResult.success) {
+    try {
+      await updateUserProfile(userId, {
+        nombres: payload.nombres,
+        apellidos: payload.apellidos,
+        genero: payload.genero,
+        id_direccion: newAddressId,
+      });
+    } catch (error) {
       // ROLLBACK: Eliminar la nueva dirección creada
       await deleteAddress(newAddressId);
 
       return {
         success: false,
         errors: {
-          form: `Error al actualizar perfil: ${profileResult.error}`,
+          form: `Error al actualizar perfil: ${getErrorMessage(error)}`,
         },
       };
     }
@@ -147,7 +150,7 @@ export async function updateProfile(
 
       if (error) {
         console.error("Error al actualizar username en auth:", error);
-        
+
         // ROLLBACK: Restaurar perfil y dirección
         await updateUserProfile(userId, {
           nombres: currentProfile.nombres,
@@ -174,11 +177,9 @@ export async function updateProfile(
     };
   } catch (error: unknown) {
     console.error("Error inesperado en updateProfile:", error);
-    const errorMessage =
-      error instanceof Error ? error.message : "Desconocido";
     return {
       success: false,
-      errors: { form: `Error inesperado: ${errorMessage}` },
+      errors: { form: `Error inesperado: ${getErrorMessage(error)}` },
     };
   }
 }

--- a/services/rules/preferenciasRules.ts
+++ b/services/rules/preferenciasRules.ts
@@ -1,20 +1,23 @@
 import { checkAuthorPreferenceExists } from "@/models/authorPreferenceModel";
 import { checkAuthorExistsById } from "@/models/authorModel";
+import { getErrorMessage } from "@/lib/services/errors";
 import type { AuthorPreferenceActionResponse } from "@/lib/types/authorPreference";
 
 export async function checkAuthorPreferenceNotDuplicate(
   id_usuario: string,
   id_autor: number
 ): Promise<AuthorPreferenceActionResponse | null> {
-  const result = await checkAuthorPreferenceExists(id_usuario, id_autor);
-  if (!result.success) {
+  let exists: boolean;
+  try {
+    exists = await checkAuthorPreferenceExists(id_usuario, id_autor);
+  } catch (error) {
     return {
       success: false,
-      errors: { form: result.error ?? "Error al verificar preferencia." },
-      message: result.error,
+      errors: { form: getErrorMessage(error) },
+      message: getErrorMessage(error),
     };
   }
-  if (result.exists) {
+  if (exists) {
     return {
       success: false,
       errors: { form: "Ya tienes este autor en tus preferencias." },
@@ -27,7 +30,16 @@ export async function checkAuthorPreferenceNotDuplicate(
 export async function checkPreferenceAuthorExists(
   id_autor: number
 ): Promise<AuthorPreferenceActionResponse | null> {
-  const exists = await checkAuthorExistsById(id_autor);
+  let exists: boolean;
+  try {
+    exists = await checkAuthorExistsById(id_autor);
+  } catch (error) {
+    return {
+      success: false,
+      errors: { form: getErrorMessage(error) },
+      message: getErrorMessage(error),
+    };
+  }
   if (!exists) {
     return {
       success: false,

--- a/services/rules/tiendaRules.ts
+++ b/services/rules/tiendaRules.ts
@@ -4,11 +4,13 @@ import {
   getActiveTiendaById,
 } from "@/models/tiendaModel";
 import { isTiendaAddressUsed } from "@/models/addressModel";
+import { getErrorMessage } from "@/lib/services/errors";
 import type {
   AddressErrorOptions,
   CreateTiendaInput,
   NameComparison,
   TiendaActionResponse,
+  TiendaRead,
   UpdateAddressDecisionParams,
   UpdateTiendaPrecheckParams,
 } from "@/lib/types/tienda";
@@ -50,7 +52,12 @@ export async function getCreateTiendaPrecheckError(
   const duplicatedTienda = await getActiveTiendaByExactName(input.nombre);
   if (duplicatedTienda) return buildDuplicatedNameResponse();
 
-  const isAddressUsed = await isTiendaAddressUsed(input.direccion_place_id);
+  let isAddressUsed: boolean;
+  try {
+    isAddressUsed = await isTiendaAddressUsed(input.direccion_place_id);
+  } catch (error) {
+    return buildAddressCreateErrorResponse({ error: getErrorMessage(error) });
+  }
   if (isAddressUsed) return buildAddressInUseResponse();
 
   return null;
@@ -102,7 +109,12 @@ async function validateAddressAvailability(
 ) {
   if (!newPlaceId || newPlaceId === currentPlaceId) return null;
 
-  const isUsed = await isTiendaAddressUsed(newPlaceId);
+  let isUsed: boolean;
+  try {
+    isUsed = await isTiendaAddressUsed(newPlaceId);
+  } catch (error) {
+    return buildAddressCreateErrorResponse({ error: getErrorMessage(error) });
+  }
   return isUsed ? buildAddressInUseResponse() : null;
 }
 export function shouldUpdateAddress({
@@ -136,7 +148,19 @@ export async function getActiveTiendaOrError(tiendaId: string): Promise<
     }
   | { success: false; response: TiendaActionResponse }
 > {
-  const tienda = await getActiveTiendaById(tiendaId);
+  let tienda: TiendaRead | null;
+  try {
+    tienda = await getActiveTiendaById(tiendaId);
+  } catch (error) {
+    return {
+      success: false,
+      response: {
+        success: false,
+        errors: { form: getErrorMessage(error) },
+        message: getErrorMessage(error),
+      },
+    };
+  }
   if (!tienda) {
     return { success: false, response: buildTiendaNotFoundResponse() };
   }

--- a/services/tiendas/tiendaService.ts
+++ b/services/tiendas/tiendaService.ts
@@ -18,7 +18,6 @@ import type {
   FetchTiendasParams,
   TiendaActionResponse,
   TiendasListResponse,
-  UpdateTiendaInput,
   UpdateTiendaParams,
   UpdateTiendaPayload,
 } from "@/lib/types/tienda";
@@ -26,6 +25,7 @@ import { requireAdminRole } from "@/lib/validations/server-auth";
 import { getCurrentUser } from "@/models/authModel";
 import { logAdminAction } from "@/services/admin/auditService";
 import { AccionAdministrador } from "@/lib/types/audit";
+import { getErrorMessage } from "@/lib/services/errors";
 import {
   buildAddressCreateErrorResponse,
   getActiveTiendaOrError,
@@ -41,16 +41,18 @@ async function createTiendaAddress({
   id?: number;
   errorResponse?: TiendaActionResponse;
 }> {
-  const addressResult = await createAddress({ direccion, placeId });
-  if (!addressResult.success || !addressResult.id) {
+  let addressId: number;
+  try {
+    addressId = await createAddress({ direccion, placeId });
+  } catch (error) {
     return {
       errorResponse: buildAddressCreateErrorResponse({
-        error: addressResult.error,
+        error: getErrorMessage(error),
       }),
     };
   }
 
-  return { id: addressResult.id };
+  return { id: addressId };
 }
 
 async function deleteAddressIfCreated({
@@ -132,17 +134,18 @@ export async function createTienda(
 
     createdAddressId = addressResult.id ?? null;
 
-    const result = await createTiendaModel({
-      nombre: input.nombre,
-      horario: input.horario,
-      id_direccion: addressResult.id as number,
-    });
-
-    if (!result.success) {
+    let newTiendaId: string;
+    try {
+      newTiendaId = await createTiendaModel({
+        nombre: input.nombre,
+        horario: input.horario,
+        id_direccion: addressResult.id as number,
+      });
+    } catch (error) {
       await deleteAddressIfCreated({ addressId: createdAddressId });
       return {
         success: false,
-        errors: { form: result.error ?? "No se pudo crear la tienda." },
+        errors: { form: getErrorMessage(error) },
         message: "No se pudo crear la tienda.",
       };
     }
@@ -151,7 +154,7 @@ export async function createTienda(
       action: AccionAdministrador.CREAR,
       description: `Se creó la tienda "${input.nombre}".`,
       entity: {
-        id: String(result.id),
+        id: String(newTiendaId),
         entity_type: "tienda",
         display_name: input.nombre,
       },
@@ -220,12 +223,13 @@ export async function updateTienda({
       payload.id_direccion = addressResult.id as number;
     }
 
-    const result = await updateTiendaById(tiendaId, payload);
-    if (!result.success) {
+    try {
+      await updateTiendaById(tiendaId, payload);
+    } catch (error) {
       await deleteAddressIfCreated({ addressId: createdAddressId });
       return {
         success: false,
-        errors: { form: result.error ?? "No se pudo actualizar la tienda." },
+        errors: { form: getErrorMessage(error) },
         message: "No se pudo actualizar la tienda.",
       };
     }
@@ -285,11 +289,12 @@ export async function deleteTienda({
       };
     }
 
-    const result = await softDeleteTiendaById(tiendaId);
-    if (!result.success) {
+    try {
+      await softDeleteTiendaById(tiendaId);
+    } catch (error) {
       return {
         success: false,
-        errors: { form: result.error ?? "No se pudo eliminar la tienda." },
+        errors: { form: getErrorMessage(error) },
         message: "No se pudo eliminar la tienda.",
       };
     }


### PR DESCRIPTION
…or handling

Models now throw on failure instead of returning { success: false, error } objects. Services and rules updated to use try-catch blocks. Changes:
- Removed ModelResult and ModelResultWithId types from lib/types/common.ts
- Refactored 13 model files to use throw error pattern
- Refactored 12 service/rule files to catch errors and return proper ActionResponse objects
- Created lib/services/errors.ts with shared getErrorMessage() helper
- Removed unused imports and variables across models and services
- Fixed libroService catch block to include actual error message
- Removed dead code (removeBook unused estado parameter) Affected models: addressModel, authModel, authorModel, authorPreferenceModel, categoryModel, copiaModel, historicoModel, libroModel, modeloRAModel, noticiaModel, tiendaModel, userModel
Affected services: registrationService, authorService, categoryService, copiaService, libroService, modeloRAService, preferenciasService, completeProfileService, profileService, tiendaRules, preferenciasRules, tiendaService