### PR TITLE
feat(preferencias): agregar soporte para preferencias de categoría co…

### DIFF
--- a/app/(with-navbar)/perfil/actions.ts
+++ b/app/(with-navbar)/perfil/actions.ts
@@ -1,19 +1,191 @@
 "use server";
 
+import { createAdminClient } from "@/lib/supabase/server";
+import { getErrorMessage } from "@/lib/services/errors";
 import { getCurrentUser } from "@/models/authModel";
+
+import { addAuthorPreference, removeAuthorPreference, getMyAuthorPreferences } from "@/services/preferencias/preferenciasService";
+import { addCategoryPreference, removeCategoryPreference, getMyCategoryPreferences } from "@/services/preferencias/preferenciasService";
+import type { AuthorPreferenceActionResponse } from "@/lib/types/authorPreference";
+import type { CategoryPreferenceActionResponse } from "@/lib/types/categoryPreference";
 import type { Genero } from "@/lib/types/auth";
 import type { ProfileUpdatePayload, ProfileUpdateResponse, EditPerfilFormValues } from "@/lib/types/profile";
 import { validateProfileUpdate } from "@/lib/validations/profile";
 import { updateProfile } from "@/services/profile/profileService";
 import { revalidatePath } from "next/cache";
-// ─── Server Action ─────────────────────────────────────────────────
+
+interface PreferenceItem {
+  id: number;
+  nombre: string;
+}
+
+interface PreferenceDataResponse {
+  success: boolean;
+  errors?: Record<string, string>;
+  message?: string;
+  authors: PreferenceItem[];
+  categories: PreferenceItem[];
+  selectedAuthorIds: number[];
+  selectedCategoryIds: number[];
+}
+
+async function getAllAuthors(): Promise<PreferenceItem[]> {
+  const adminClient = createAdminClient();
+  const { data, error } = await adminClient
+    .from("autor")
+    .select("id, nombre")
+    .is("deleted_at", null)
+    .order("nombre", { ascending: true });
+
+  if (error) throw error;
+  return (data ?? []).map(row => ({ id: row.id, nombre: row.nombre }));
+}
+
+async function getAllCategories(): Promise<PreferenceItem[]> {
+  const adminClient = createAdminClient();
+  const { data, error } = await adminClient
+    .from("categoria")
+    .select("id, nombre")
+    .is("deleted_at", null)
+    .order("nombre", { ascending: true });
+
+  if (error) throw error;
+  return (data ?? []).map(row => ({ id: row.id, nombre: row.nombre }));
+}
+
+export async function getPreferenceDataAction(): Promise<PreferenceDataResponse> {
+  const user = await getCurrentUser();
+  if (!user) {
+    return {
+      success: false,
+      errors: { form: "No hay sesión activa." },
+      authors: [],
+      categories: [],
+      selectedAuthorIds: [],
+      selectedCategoryIds: [],
+    };
+  }
+
+  try {
+    const [authorPrefsResult, categoryPrefsResult, authorsData, categoriesData] = await Promise.all([
+      getMyAuthorPreferences(),
+      getMyCategoryPreferences(),
+      getAllAuthors(),
+      getAllCategories(),
+    ]);
+
+    const selectedAuthorIds = authorPrefsResult.success && authorPrefsResult.data
+      ? authorPrefsResult.data.map(p => p.id_autor)
+      : [];
+
+    const selectedCategoryIds = categoryPrefsResult.success && categoryPrefsResult.data
+      ? categoryPrefsResult.data.map(p => p.id_categoria)
+      : [];
+
+    return {
+      success: true,
+      authors: authorsData,
+      categories: categoriesData,
+      selectedAuthorIds,
+      selectedCategoryIds,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      errors: { form: getErrorMessage(error) },
+      authors: [],
+      categories: [],
+      selectedAuthorIds: [],
+      selectedCategoryIds: [],
+    };
+  }
+}
+
+export async function updateAuthorPreferencesAction(
+  authorIds: number[]
+): Promise<AuthorPreferenceActionResponse> {
+  const user = await getCurrentUser();
+  if (!user) {
+    return { success: false, errors: { form: "No hay sesión activa." }, message: "No hay sesión activa." };
+  }
+
+  try {
+    const currentResult = await getMyAuthorPreferences();
+    if (!currentResult.success || !currentResult.data) {
+      return { success: false, errors: { form: currentResult.message ?? "Error al obtener preferencias." }, message: currentResult.message };
+    }
+
+    const currentIds = currentResult.data.map(p => p.id_autor);
+    const toAdd = authorIds.filter(id => !currentIds.includes(id));
+    const toRemove = currentIds.filter(id => !authorIds.includes(id));
+
+    const removeResults = await Promise.all(
+      toRemove.map(id_autor => removeAuthorPreference(id_autor))
+    );
+    const removeFailed = removeResults.find(r => !r.success);
+    if (removeFailed) {
+      return { success: false, errors: removeFailed.errors ?? { form: removeFailed.message ?? "Error" }, message: removeFailed.message };
+    }
+
+    const addResults = await Promise.all(
+      toAdd.map(id_autor => addAuthorPreference({ id_autor }))
+    );
+    const addFailed = addResults.find(r => !r.success);
+    if (addFailed) {
+      return { success: false, errors: addFailed.errors ?? { form: addFailed.message ?? "Error" }, message: addFailed.message };
+    }
+
+    return { success: true };
+  } catch (error) {
+    return { success: false, errors: { form: getErrorMessage(error) }, message: getErrorMessage(error) };
+  }
+}
+
+export async function updateCategoryPreferencesAction(
+  categoryIds: number[]
+): Promise<CategoryPreferenceActionResponse> {
+  const user = await getCurrentUser();
+  if (!user) {
+    return { success: false, errors: { form: "No hay sesión activa." }, message: "No hay sesión activa." };
+  }
+
+  try {
+    const currentResult = await getMyCategoryPreferences();
+    if (!currentResult.success || !currentResult.data) {
+      return { success: false, errors: { form: currentResult.message ?? "Error al obtener preferencias." }, message: currentResult.message };
+    }
+
+    const currentIds = currentResult.data.map(p => p.id_categoria);
+    const toAdd = categoryIds.filter(id => !currentIds.includes(id));
+    const toRemove = currentIds.filter(id => !categoryIds.includes(id));
+
+    const removeResults = await Promise.all(
+      toRemove.map(id_categoria => removeCategoryPreference(id_categoria))
+    );
+    const removeFailed = removeResults.find(r => !r.success);
+    if (removeFailed) {
+      return { success: false, errors: removeFailed.errors ?? { form: removeFailed.message ?? "Error" }, message: removeFailed.message };
+    }
+
+    const addResults = await Promise.all(
+      toAdd.map(id_categoria => addCategoryPreference({ id_categoria }))
+    );
+    const addFailed = addResults.find(r => !r.success);
+    if (addFailed) {
+      return { success: false, errors: addFailed.errors ?? { form: addFailed.message ?? "Error" }, message: addFailed.message };
+    }
+
+    return { success: true };
+  } catch (error) {
+    return { success: false, errors: { form: getErrorMessage(error) }, message: getErrorMessage(error) };
+  }
+}
 
 export async function updateProfileAction(
   formData: EditPerfilFormValues,
   formattedAddress: string,
   placeId: string
 ): Promise<ProfileUpdateResponse> {
-  // 1. Verificar autenticación
   const user = await getCurrentUser();
   if (!user) {
     return {
@@ -22,12 +194,11 @@ export async function updateProfileAction(
     };
   }
 
-  // 2. Validar y sanitizar solo campos editables
-  const { errors, sanitized } = validateProfileUpdate({ //se manda a verificar solo los campos editables, el payload se construye en la acción a partir de esos valores y de los otros datos como la dirección
+  const { errors, sanitized } = validateProfileUpdate({
     nombres: formData.nombres,
     apellidos: formData.apellidos,
     genero: formData.genero as Genero,
-    usuario: formData.usuario,  
+    usuario: formData.usuario,
     direccion: formattedAddress,
     direccion_place_id: placeId,
     direccion_detalle: formData.direccion_detalle,
@@ -37,13 +208,11 @@ export async function updateProfileAction(
     return { success: false, errors };
   }
 
-  // 3. Construir payload con datos sanitizados
   const payload: ProfileUpdatePayload = {
     ...sanitized,
-    genero: sanitized.genero as Genero, // Type assertion: la validación garantiza que no es ""
-  }; 
+    genero: sanitized.genero as Genero,
+  };
 
-  // 4. Delegar al servicio
   try {
     const result = await updateProfile(payload);
 

--- a/components/profile/ClientModules.tsx
+++ b/components/profile/ClientModules.tsx
@@ -2,8 +2,7 @@
 
 import { useState } from "react";
 import Modal from "@/components/ui/Modal";
-
-
+import PreferenciasLiterariasSection from "./PreferenciasLiterariasSection";
 
 // ─── Componente principal ──────────────────────────────────────────
 
@@ -21,24 +20,7 @@ export default function ClientModules() {
             {/* Tarjetas de módulos */}
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-5 mt-6">
                 {/* Preferencias Literarias */}
-                <button
-                    type="button"
-                    onClick={() => handleOpenModal("Preferencias Literarias")}
-                    className="text-left bg-white border border-brand-accent/25 rounded-lg p-6 shadow-[0_1px_3px_rgba(10,9,8,0.04)] transition-all hover:border-brand-primary hover:shadow-lg hover:-translate-y-0.5 cursor-pointer group"
-                >
-                    <div className="w-12 h-12 rounded-full bg-brand-accent/12 grid place-items-center mb-3">
-                        <svg className="w-6 h-6 text-brand-primary" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                            <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
-                            <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
-                        </svg>
-                    </div>
-                    <h3 className="font-display text-lg font-semibold text-brand-primary mb-1.5 tracking-wide group-hover:underline underline-offset-2">
-                        Preferencias Literarias
-                    </h3>
-                    <p className="text-sm text-brand-secondary font-light leading-relaxed">
-                        Administra tus géneros favoritos y recibe recomendaciones personalizadas de libros.
-                    </p>
-                </button>
+                <PreferenciasLiterariasSection />
 
                 {/* Gestión Financiera */}
                 <button

--- a/components/profile/PreferenceTabSwitcher.tsx
+++ b/components/profile/PreferenceTabSwitcher.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+type PreferenceTab = "autores" | "categorias";
+
+interface PreferenceTabSwitcherProps {
+  activeTab: PreferenceTab;
+  onTabChange: (tab: PreferenceTab) => void;
+}
+
+const TABS: Array<{ key: PreferenceTab; label: string }> = [
+  { key: "autores", label: "Autores" },
+  { key: "categorias", label: "Categorías" },
+];
+
+export default function PreferenceTabSwitcher({
+  activeTab,
+  onTabChange,
+}: PreferenceTabSwitcherProps) {
+  return (
+    <div className="flex gap-1 mb-3">
+      {TABS.map(({ key, label }) => (
+        <button
+          key={key}
+          type="button"
+          onClick={() => onTabChange(key)}
+          className={`px-4 py-1.5 text-sm rounded-full transition-all cursor-pointer ${
+            activeTab === key
+              ? "bg-brand-primary text-brand-bg font-medium"
+              : "bg-brand-accent/10 text-brand-secondary hover:bg-brand-accent/20"
+          }`}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/components/profile/PreferenciasCard.tsx
+++ b/components/profile/PreferenciasCard.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+interface PreferenciasCardProps {
+  authorCount: number;
+  categoryCount: number;
+  onOpen: () => void;
+}
+
+export default function PreferenciasCard({
+  authorCount,
+  categoryCount,
+  onOpen,
+}: PreferenciasCardProps) {
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      className="text-left bg-white border border-brand-accent/25 rounded-lg p-6 shadow-[0_1px_3px_rgba(10,9,8,0.04)] transition-all hover:border-brand-primary hover:shadow-lg hover:-translate-y-0.5 cursor-pointer group w-full"
+    >
+      <div className="w-12 h-12 rounded-full bg-brand-accent/12 grid place-items-center mb-3">
+        <svg className="w-6 h-6 text-brand-primary" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
+          <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
+        </svg>
+      </div>
+      <h3 className="font-display text-lg font-semibold text-brand-primary mb-1.5 tracking-wide group-hover:underline underline-offset-2">
+        Preferencias Literarias
+      </h3>
+      <p className="text-sm text-brand-secondary font-light leading-relaxed">
+        Administra tus géneros favoritos y recibe recomendaciones personalizadas de libros.
+      </p>
+      <div className="mt-3 flex gap-2">
+        {authorCount > 0 && (
+          <span className="text-xs bg-brand-accent/15 text-brand-secondary px-2 py-0.5 rounded-full">
+            {authorCount} autores
+          </span>
+        )}
+        {categoryCount > 0 && (
+          <span className="text-xs bg-brand-accent/15 text-brand-secondary px-2 py-0.5 rounded-full">
+            {categoryCount} categorías
+          </span>
+        )}
+      </div>
+    </button>
+  );
+}

--- a/components/profile/PreferenciasLiterariasSection.tsx
+++ b/components/profile/PreferenciasLiterariasSection.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import PreferenceSelectionModal from "@/components/ui/PreferenceSelectionModal";
+import Alert from "@/components/ui/Alert";
+import { 
+  getPreferenceDataAction, 
+  updateAuthorPreferencesAction, 
+  updateCategoryPreferencesAction 
+} from "@/app/(with-navbar)/perfil/actions";
+
+interface PreferenceItem {
+  id: number;
+  nombre: string;
+}
+
+export default function PreferenciasLiterariasSection() {
+  const [modalOpen, setModalOpen] = useState(false);
+  const [activeTab, setActiveTab] = useState<"autores" | "categorias">("autores");
+  const [selectedAuthorIds, setSelectedAuthorIds] = useState<number[]>([]);
+  const [selectedCategoryIds, setSelectedCategoryIds] = useState<number[]>([]);
+  const [allAuthors, setAllAuthors] = useState<PreferenceItem[]>([]);
+  const [allCategories, setAllCategories] = useState<PreferenceItem[]>([]);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [notification, setNotification] = useState<{ type: "success" | "error"; message: string } | null>(null);
+
+  useEffect(() => {
+    if (!modalOpen) return;
+
+    let ignore = false;
+    setIsLoading(true);
+
+    (async () => {
+      try {
+        const result = await getPreferenceDataAction();
+        if (ignore) return;
+
+        if (result.success) {
+          setAllAuthors(result.authors);
+          setAllCategories(result.categories);
+          setSelectedAuthorIds(result.selectedAuthorIds);
+          setSelectedCategoryIds(result.selectedCategoryIds);
+        } else {
+          showNotification("error", result.errors?.form ?? "Error al cargar datos");
+        }
+      } catch {
+        if (!ignore) {
+          showNotification("error", "Error inesperado al cargar preferencias");
+        }
+      } finally {
+        if (!ignore) setIsLoading(false);
+      }
+    })();
+
+    return () => { ignore = true; };
+  }, [modalOpen]);
+
+  function showNotification(type: "success" | "error", message: string) {
+    setNotification({ type, message });
+    setTimeout(() => setNotification(null), 4000);
+  }
+
+  async function handleSave() {
+    setIsSaving(true);
+    try {
+      const [authorResult, categoryResult] = await Promise.all([
+        updateAuthorPreferencesAction(selectedAuthorIds),
+        updateCategoryPreferencesAction(selectedCategoryIds),
+      ]);
+
+      if (authorResult.success && categoryResult.success) {
+        showNotification("success", "Preferencias guardadas correctamente");
+        setModalOpen(false);
+      } else {
+        const errorMsg = !authorResult.success 
+          ? authorResult.errors?.form ?? authorResult.message
+          : categoryResult.errors?.form ?? categoryResult.message;
+        showNotification("error", errorMsg ?? "Error al guardar");
+      }
+    } catch {
+      showNotification("error", "Error inesperado al guardar");
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  function handleClearAll() {
+    if (activeTab === "autores") {
+      setSelectedAuthorIds([]);
+    } else {
+      setSelectedCategoryIds([]);
+    }
+  }
+
+  const currentItems = activeTab === "autores" ? allAuthors : allCategories;
+  const currentSelectedIds = activeTab === "autores" ? selectedAuthorIds : selectedCategoryIds;
+  const setCurrentSelectedIds = activeTab === "autores" ? setSelectedAuthorIds : setSelectedCategoryIds;
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setModalOpen(true)}
+        className="text-left bg-white border border-brand-accent/25 rounded-lg p-6 shadow-[0_1px_3px_rgba(10,9,8,0.04)] transition-all hover:border-brand-primary hover:shadow-lg hover:-translate-y-0.5 cursor-pointer group w-full"
+      >
+        <div className="w-12 h-12 rounded-full bg-brand-accent/12 grid place-items-center mb-3">
+          <svg className="w-6 h-6 text-brand-primary" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
+            <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
+          </svg>
+        </div>
+        <h3 className="font-display text-lg font-semibold text-brand-primary mb-1.5 tracking-wide group-hover:underline underline-offset-2">
+          Preferencias Literarias
+        </h3>
+        <p className="text-sm text-brand-secondary font-light leading-relaxed">
+          Administra tus géneros favoritos y recibe recomendaciones personalizadas de libros.
+        </p>
+        <div className="mt-3 flex gap-2">
+          {selectedAuthorIds.length > 0 && (
+            <span className="text-xs bg-brand-accent/15 text-brand-secondary px-2 py-0.5 rounded-full">
+              {selectedAuthorIds.length} autores
+            </span>
+          )}
+          {selectedCategoryIds.length > 0 && (
+            <span className="text-xs bg-brand-accent/15 text-brand-secondary px-2 py-0.5 rounded-full">
+              {selectedCategoryIds.length} categorías
+            </span>
+          )}
+        </div>
+      </button>
+
+      <PreferenceSelectionModal
+        isOpen={modalOpen}
+        onClose={() => setModalOpen(false)}
+        title={activeTab === "autores" ? "Preferencias de Autores" : "Preferencias de Categorías"}
+        subtitle="Selecciona los elementos que te interesen"
+        items={currentItems}
+        selectedIds={currentSelectedIds}
+        onSelectionChange={setCurrentSelectedIds}
+        onSave={handleSave}
+        onClearAll={handleClearAll}
+        isSaving={isSaving}
+        isLoading={isLoading}
+        tabSwitcher={
+          <div className="flex gap-1 mb-3">
+            <button
+              type="button"
+              onClick={() => setActiveTab("autores")}
+              className={`px-4 py-1.5 text-sm rounded-full transition-all cursor-pointer ${
+                activeTab === "autores"
+                  ? "bg-brand-primary text-brand-bg font-medium"
+                  : "bg-brand-accent/10 text-brand-secondary hover:bg-brand-accent/20"
+              }`}
+            >
+              Autores
+            </button>
+            <button
+              type="button"
+              onClick={() => setActiveTab("categorias")}
+              className={`px-4 py-1.5 text-sm rounded-full transition-all cursor-pointer ${
+                activeTab === "categorias"
+                  ? "bg-brand-primary text-brand-bg font-medium"
+                  : "bg-brand-accent/10 text-brand-secondary hover:bg-brand-accent/20"
+              }`}
+            >
+              Categorías
+            </button>
+          </div>
+        }
+      />
+
+      {notification && (
+        <div className="fixed bottom-6 right-6 z-50">
+          <Alert variant={notification.type === "success" ? "success" : "error"}>
+            {notification.message}
+          </Alert>
+        </div>
+      )}
+    </>
+  );
+}

--- a/components/profile/PreferenciasLiterariasSection.tsx
+++ b/components/profile/PreferenciasLiterariasSection.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useEffect } from "react";
 import PreferenceSelectionModal from "@/components/ui/PreferenceSelectionModal";
+import PreferenciasCard from "@/components/profile/PreferenciasCard";
+import PreferenceTabSwitcher from "@/components/profile/PreferenceTabSwitcher";
 import Alert from "@/components/ui/Alert";
 import { 
   getPreferenceDataAction, 
@@ -12,6 +14,14 @@ import {
 interface PreferenceItem {
   id: number;
   nombre: string;
+}
+
+function extractSaveError(
+  authorResult: { success: boolean; errors?: Record<string, string>; message?: string },
+  categoryResult: { success: boolean; errors?: Record<string, string>; message?: string }
+): string {
+  const failed = !authorResult.success ? authorResult : categoryResult;
+  return failed.errors?.form ?? failed.message ?? "Error al guardar";
 }
 
 export default function PreferenciasLiterariasSection() {
@@ -73,10 +83,7 @@ export default function PreferenciasLiterariasSection() {
         showNotification("success", "Preferencias guardadas correctamente");
         setModalOpen(false);
       } else {
-        const errorMsg = !authorResult.success 
-          ? authorResult.errors?.form ?? authorResult.message
-          : categoryResult.errors?.form ?? categoryResult.message;
-        showNotification("error", errorMsg ?? "Error al guardar");
+        showNotification("error", extractSaveError(authorResult, categoryResult));
       }
     } catch {
       showNotification("error", "Error inesperado al guardar");
@@ -99,36 +106,11 @@ export default function PreferenciasLiterariasSection() {
 
   return (
     <>
-      <button
-        type="button"
-        onClick={() => setModalOpen(true)}
-        className="text-left bg-white border border-brand-accent/25 rounded-lg p-6 shadow-[0_1px_3px_rgba(10,9,8,0.04)] transition-all hover:border-brand-primary hover:shadow-lg hover:-translate-y-0.5 cursor-pointer group w-full"
-      >
-        <div className="w-12 h-12 rounded-full bg-brand-accent/12 grid place-items-center mb-3">
-          <svg className="w-6 h-6 text-brand-primary" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
-            <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
-          </svg>
-        </div>
-        <h3 className="font-display text-lg font-semibold text-brand-primary mb-1.5 tracking-wide group-hover:underline underline-offset-2">
-          Preferencias Literarias
-        </h3>
-        <p className="text-sm text-brand-secondary font-light leading-relaxed">
-          Administra tus géneros favoritos y recibe recomendaciones personalizadas de libros.
-        </p>
-        <div className="mt-3 flex gap-2">
-          {selectedAuthorIds.length > 0 && (
-            <span className="text-xs bg-brand-accent/15 text-brand-secondary px-2 py-0.5 rounded-full">
-              {selectedAuthorIds.length} autores
-            </span>
-          )}
-          {selectedCategoryIds.length > 0 && (
-            <span className="text-xs bg-brand-accent/15 text-brand-secondary px-2 py-0.5 rounded-full">
-              {selectedCategoryIds.length} categorías
-            </span>
-          )}
-        </div>
-      </button>
+      <PreferenciasCard
+        authorCount={selectedAuthorIds.length}
+        categoryCount={selectedCategoryIds.length}
+        onOpen={() => setModalOpen(true)}
+      />
 
       <PreferenceSelectionModal
         isOpen={modalOpen}
@@ -143,30 +125,10 @@ export default function PreferenciasLiterariasSection() {
         isSaving={isSaving}
         isLoading={isLoading}
         tabSwitcher={
-          <div className="flex gap-1 mb-3">
-            <button
-              type="button"
-              onClick={() => setActiveTab("autores")}
-              className={`px-4 py-1.5 text-sm rounded-full transition-all cursor-pointer ${
-                activeTab === "autores"
-                  ? "bg-brand-primary text-brand-bg font-medium"
-                  : "bg-brand-accent/10 text-brand-secondary hover:bg-brand-accent/20"
-              }`}
-            >
-              Autores
-            </button>
-            <button
-              type="button"
-              onClick={() => setActiveTab("categorias")}
-              className={`px-4 py-1.5 text-sm rounded-full transition-all cursor-pointer ${
-                activeTab === "categorias"
-                  ? "bg-brand-primary text-brand-bg font-medium"
-                  : "bg-brand-accent/10 text-brand-secondary hover:bg-brand-accent/20"
-              }`}
-            >
-              Categorías
-            </button>
-          </div>
+          <PreferenceTabSwitcher
+            activeTab={activeTab}
+            onTabChange={setActiveTab}
+          />
         }
       />
 

--- a/components/ui/PreferenceItemsList.tsx
+++ b/components/ui/PreferenceItemsList.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { TagChip } from "@/components/ui/TagChip";
+
+interface PreferenceItem {
+  id: number;
+  nombre: string;
+}
+
+interface PreferenceItemsListProps {
+  isLoading: boolean;
+  items: PreferenceItem[];
+  filteredItems: PreferenceItem[];
+  selectedIds: number[];
+  titleKey: string;
+  onToggle: (id: number) => void;
+}
+
+export default function PreferenceItemsList({
+  isLoading,
+  items,
+  filteredItems,
+  selectedIds,
+  titleKey,
+  onToggle,
+}: PreferenceItemsListProps) {
+  if (isLoading) {
+    return (
+      <div className="p-4 flex items-center justify-center w-full">
+        <div className="w-5 h-5 border-2 border-brand-accent/30 border-t-brand-primary rounded-full animate-spin" />
+        <span className="ml-2 text-sm text-brand-secondary">Cargando...</span>
+      </div>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <p className="p-4 text-center text-brand-secondary text-sm w-full">
+        No hay elementos disponibles
+      </p>
+    );
+  }
+
+  if (filteredItems.length === 0) {
+    return (
+      <p className="p-4 text-center text-brand-secondary text-sm w-full">
+        No se encontraron resultados
+      </p>
+    );
+  }
+
+  return (
+    <>
+      {filteredItems.map((item) => (
+        <TagChip
+          key={`${titleKey}-${item.id}`}
+          label={item.nombre}
+          isSelected={selectedIds.includes(item.id)}
+          onClick={() => onToggle(item.id)}
+        />
+      ))}
+    </>
+  );
+}

--- a/components/ui/PreferenceSelectionModal.tsx
+++ b/components/ui/PreferenceSelectionModal.tsx
@@ -3,7 +3,7 @@
 import { Search } from "lucide-react";
 import { useState, useEffect } from "react";
 import Button from "@/components/ui/Button";
-import { TagChip } from "@/components/ui/TagChip";
+import PreferenceItemsList from "@/components/ui/PreferenceItemsList";
 import Modal from "@/components/ui/Modal";
 
 export interface PreferenceSelectionModalProps {
@@ -94,29 +94,14 @@ export default function PreferenceSelectionModal({
             </div>
           )}
           <div className="flex flex-wrap gap-2 max-h-72 overflow-y-auto py-1">
-            {isLoading ? (
-              <div className="p-4 flex items-center justify-center w-full">
-                <div className="w-5 h-5 border-2 border-brand-accent/30 border-t-brand-primary rounded-full animate-spin" />
-                <span className="ml-2 text-sm text-brand-secondary">Cargando...</span>
-              </div>
-            ) : items.length === 0 ? (
-              <p className="p-4 text-center text-brand-secondary text-sm w-full">
-                No hay elementos disponibles
-              </p>
-            ) : filteredItems.length === 0 ? (
-              <p className="p-4 text-center text-brand-secondary text-sm w-full">
-                No se encontraron resultados
-              </p>
-            ) : (
-              filteredItems.map((item) => (
-                <TagChip
-                  key={`${title}-${item.id}`}
-                  label={item.nombre}
-                  isSelected={selectedIds.includes(item.id)}
-                  onClick={() => handleToggle(item.id)}
-                />
-              ))
-            )}
+            <PreferenceItemsList
+              isLoading={isLoading}
+              items={items}
+              filteredItems={filteredItems}
+              selectedIds={selectedIds}
+              titleKey={title}
+              onToggle={handleToggle}
+            />
           </div>
         </div>
 

--- a/components/ui/PreferenceSelectionModal.tsx
+++ b/components/ui/PreferenceSelectionModal.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { Search } from "lucide-react";
+import { useState, useEffect } from "react";
+import Button from "@/components/ui/Button";
+import { TagChip } from "@/components/ui/TagChip";
+import Modal from "@/components/ui/Modal";
+
+export interface PreferenceSelectionModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  subtitle?: string;
+  items: Array<{ id: number; nombre: string }>;
+  selectedIds: number[];
+  onSelectionChange: (ids: number[]) => void;
+  onSave: () => void;
+  onClearAll: () => void;
+  isSaving?: boolean;
+  isLoading?: boolean;
+  tabSwitcher?: React.ReactNode;
+}
+
+export default function PreferenceSelectionModal({
+  isOpen,
+  onClose,
+  title,
+  subtitle,
+  items,
+  selectedIds,
+  onSelectionChange,
+  onSave,
+  onClearAll,
+  isSaving = false,
+  isLoading = false,
+  tabSwitcher,
+}: PreferenceSelectionModalProps) {
+  const [searchTerm, setSearchTerm] = useState("");
+
+  useEffect(() => {
+    setSearchTerm("");
+  }, [title]);
+
+  const filteredItems = items.filter((item) =>
+    item.nombre.toLowerCase().includes(searchTerm.toLowerCase())
+  );
+
+  const handleToggle = (id: number) => {
+    if (selectedIds.includes(id)) {
+      onSelectionChange(selectedIds.filter((selectedId) => selectedId !== id));
+    } else {
+      onSelectionChange([...selectedIds, id]);
+    }
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={title}
+      maxWidth="lg"
+    >
+      <div className="space-y-4">
+        {(subtitle || tabSwitcher) && (
+          <div className="space-y-1 mb-2">
+            {subtitle && (
+              <p className="text-brand-secondary text-sm">{subtitle}</p>
+            )}
+            {tabSwitcher && <div className="mt-3">{tabSwitcher}</div>}
+          </div>
+        )}
+
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-brand-accent" />
+          <input
+            type="text"
+            placeholder="Buscar..."
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            className="w-full pl-10 pr-4 py-2 bg-brand-bg text-brand-text placeholder:text-brand-accent rounded-lg border border-brand-accent/20 focus:outline-none focus:ring-2 focus:ring-brand-accent/60 focus:border-brand-primary transition-all duration-200 text-sm"
+          />
+        </div>
+
+        <div className="flex flex-col gap-2">
+          {items.length > 0 && (
+            <div className="flex justify-end">
+              <button
+                onClick={onClearAll}
+                disabled={isLoading}
+                className="text-sm text-brand-secondary hover:text-brand-primary underline transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Limpiar todo
+              </button>
+            </div>
+          )}
+          <div className="flex flex-wrap gap-2 max-h-72 overflow-y-auto py-1">
+            {isLoading ? (
+              <div className="p-4 flex items-center justify-center w-full">
+                <div className="w-5 h-5 border-2 border-brand-accent/30 border-t-brand-primary rounded-full animate-spin" />
+                <span className="ml-2 text-sm text-brand-secondary">Cargando...</span>
+              </div>
+            ) : items.length === 0 ? (
+              <p className="p-4 text-center text-brand-secondary text-sm w-full">
+                No hay elementos disponibles
+              </p>
+            ) : filteredItems.length === 0 ? (
+              <p className="p-4 text-center text-brand-secondary text-sm w-full">
+                No se encontraron resultados
+              </p>
+            ) : (
+              filteredItems.map((item) => (
+                <TagChip
+                  key={`${title}-${item.id}`}
+                  label={item.nombre}
+                  isSelected={selectedIds.includes(item.id)}
+                  onClick={() => handleToggle(item.id)}
+                />
+              ))
+            )}
+          </div>
+        </div>
+
+        <div className="border-t border-brand-accent/10 pt-4 flex justify-end gap-3">
+          <Button variant="secondary" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button variant="primary" onClick={onSave} disabled={isSaving || isLoading}>
+            {isSaving ? "Guardando..." : "Guardar"}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/components/ui/TagChip.tsx
+++ b/components/ui/TagChip.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+export interface TagChipProps {
+  label: string;
+  isSelected: boolean;
+  onClick: () => void;
+}
+
+export function TagChip({ label, isSelected, onClick }: TagChipProps) {
+  const baseClasses =
+    "inline-flex items-center rounded-full px-3 py-1.5 text-sm font-medium transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-offset-1 cursor-pointer";
+
+  const inactiveClasses =
+    "border border-brand-accent/30 bg-brand-bg text-brand-text hover:border-brand-accent/60 focus:ring-brand-accent/60";
+
+  const activeClasses =
+    "border-2 border-brand-primary bg-brand-primary/10 text-brand-primary hover:border-brand-primary/70 focus:ring-brand-accent/60";
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (e.key === " " || e.key === "Enter") {
+      e.preventDefault();
+      onClick();
+    }
+  };
+
+  return (
+    <button
+      role="checkbox"
+      aria-checked={isSelected}
+      tabIndex={0}
+      onClick={onClick}
+      onKeyDown={handleKeyDown}
+      className={`${baseClasses} ${isSelected ? activeClasses : inactiveClasses}`}
+    >
+      {label}
+    </button>
+  );
+}

--- a/lib/preferencias/preferenceQueryBuilder.ts
+++ b/lib/preferencias/preferenceQueryBuilder.ts
@@ -1,0 +1,51 @@
+import { createAdminClient } from "@/lib/supabase/server";
+
+export type PreferenceTarget = "autor" | "categoria";
+export type SoftDeleteFilter = "active" | "all";
+
+const TABLE_NAMES: Record<PreferenceTarget, "preferencia_autor" | "preferencia_categoria"> = {
+  autor: "preferencia_autor",
+  categoria: "preferencia_categoria",
+};
+
+const TARGET_ID_FIELD: Record<PreferenceTarget, "id_autor" | "id_categoria"> = {
+  autor: "id_autor",
+  categoria: "id_categoria",
+};
+
+const ERROR_PREFIX = "[preferenceQueryBuilder]";
+
+export async function findPreferenceId(
+  target: PreferenceTarget,
+  id_usuario: string,
+  targetId: number,
+  softDeleteFilter: SoftDeleteFilter
+): Promise<number | null> {
+  const adminClient = createAdminClient();
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let query: any = adminClient
+    .from(TABLE_NAMES[target])
+    .select("id")
+    .eq("id_usuario", id_usuario)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .eq(TARGET_ID_FIELD[target] as any, targetId)
+    .limit(1)
+    .maybeSingle();
+
+  if (softDeleteFilter === "active") {
+    query = query.is("deleted_at", null);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    console.error(
+      `${ERROR_PREFIX} Error al buscar preferencia de ${target}:`,
+      error
+    );
+    throw error;
+  }
+
+  return data?.id ?? null;
+}

--- a/lib/preferencias/preferenciaServiceUtils.ts
+++ b/lib/preferencias/preferenciaServiceUtils.ts
@@ -1,0 +1,19 @@
+import { requireClientRole } from "@/lib/validations/server-auth";
+import { getCurrentUser } from "@/models/authModel";
+import type { ActionResponse } from "@/lib/types/common";
+import type { User } from "@supabase/supabase-js";
+
+export async function getAuthenticatedUser(): Promise<
+  { success: true; user: User } |
+  ActionResponse
+> {
+  const roleCheck = await requireClientRole();
+  if (!roleCheck.success) return roleCheck;
+
+  const user = await getCurrentUser();
+  if (!user) {
+    return { success: false, errors: { form: "No hay sesión activa." }, message: "No hay sesión activa." };
+  }
+
+  return { success: true, user };
+}

--- a/lib/types/authorPreference.ts
+++ b/lib/types/authorPreference.ts
@@ -1,6 +1,6 @@
 import type { Database } from "@/lib/types/supabase";
 import type { AuthorRow } from "./author";
-import type { ActionResponse, DataResponse } from "@/lib/types/common";
+import type { PreferenceActionResponse, PreferenceDataResponse } from "./preferencia";
 
 export type AuthorPreferenceRow =
   Database["public"]["Tables"]["preferencia_autor"]["Row"];
@@ -23,8 +23,6 @@ export interface AuthorPreferenceWithDetails extends AuthorPreferenceRow {
   autor: AuthorPreferenceAuthorSummary | null;
 }
 
-export interface AuthorPreferenceActionResponse extends ActionResponse {
-  id?: number;
-}
+export type AuthorPreferenceActionResponse = PreferenceActionResponse;
 
-export type AuthorPreferenceDataResponse = DataResponse<AuthorPreferenceWithDetails[]>;
+export type AuthorPreferenceDataResponse = PreferenceDataResponse<AuthorPreferenceWithDetails>;

--- a/lib/types/categoryPreference.ts
+++ b/lib/types/categoryPreference.ts
@@ -1,0 +1,25 @@
+import type { Database } from "@/lib/types/supabase";
+import type { CategoryRow } from "./category";
+import type { PreferenceActionResponse, PreferenceDataResponse } from "./preferencia";
+
+export type CategoryPreferenceRow =
+  Database["public"]["Tables"]["preferencia_categoria"]["Row"];
+
+export interface AddCategoryPreferenceInput {
+  id_categoria: number;
+}
+
+export interface InsertCategoryPreferencePayload {
+  id_usuario: string;
+  id_categoria: number;
+}
+
+export type CategoryPreferenceCategorySummary = Pick<CategoryRow, "id" | "nombre">;
+
+export interface CategoryPreferenceWithDetails extends CategoryPreferenceRow {
+  categoria: CategoryPreferenceCategorySummary | null;
+}
+
+export type CategoryPreferenceActionResponse = PreferenceActionResponse;
+
+export type CategoryPreferenceDataResponse = PreferenceDataResponse<CategoryPreferenceWithDetails>;

--- a/lib/types/preferencia.ts
+++ b/lib/types/preferencia.ts
@@ -1,0 +1,13 @@
+import type { ActionResponse, DataResponse } from "./common";
+
+/**
+ * Generic action response for preference operations (author + category).
+ */
+export interface PreferenceActionResponse extends ActionResponse {
+  id?: number;
+}
+
+/**
+ * Generic data response for preference listings.
+ */
+export type PreferenceDataResponse<T> = DataResponse<T[]>;

--- a/models/authorPreferenceModel.ts
+++ b/models/authorPreferenceModel.ts
@@ -74,10 +74,59 @@ async function findAuthorPreferenceId(
   return data?.id ?? null;
 }
 
-export async function insertAuthorPreference(
+async function findAuthorPreferenceIdIncludingDeleted(
+  id_usuario: string,
+  id_autor: number
+): Promise<number | null> {
+  const adminClient = createAdminClient();
+
+  const { data, error } = await adminClient
+    .from("preferencia_autor")
+    .select("id")
+    .eq("id_usuario", id_usuario)
+    .eq("id_autor", id_autor)
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    console.error(
+      "[authorPreferenceModel] Error al verificar preferencia (incluyendo eliminadas):",
+      error
+    );
+    throw error;
+  }
+
+  return data?.id ?? null;
+}
+
+export async function insertOrRestoreAuthorPreference(
   data: InsertAuthorPreferencePayload
 ): Promise<number> {
   const adminClient = createAdminClient();
+
+  const existingId = await findAuthorPreferenceIdIncludingDeleted(
+    data.id_usuario,
+    data.id_autor
+  );
+
+  if (existingId !== null) {
+    const { data: updatedRows, error } = await adminClient
+      .from("preferencia_autor")
+      .update({ deleted_at: null })
+      .eq("id", existingId)
+      .select("id")
+      .single();
+
+    if (error) {
+      console.error(
+        "[authorPreferenceModel] Error al restaurar preferencia de autor:",
+        error
+      );
+      throw error;
+    }
+
+    return updatedRows!.id;
+  }
 
   const { data: resultData, error } = await adminClient
     .from("preferencia_autor")

--- a/models/authorPreferenceModel.ts
+++ b/models/authorPreferenceModel.ts
@@ -1,4 +1,5 @@
 import { createAdminClient } from "@/lib/supabase/server";
+import { findPreferenceId } from "@/lib/preferencias/preferenceQueryBuilder";
 import type {
   InsertAuthorPreferencePayload,
   AuthorPreferenceAuthorSummary,
@@ -52,88 +53,44 @@ async function findAuthorPreferenceId(
   id_usuario: string,
   id_autor: number
 ): Promise<number | null> {
-  const adminClient = createAdminClient();
-
-  const { data, error } = await adminClient
-    .from("preferencia_autor")
-    .select("id")
-    .eq("id_usuario", id_usuario)
-    .eq("id_autor", id_autor)
-    .is("deleted_at", null)
-    .limit(1)
-    .maybeSingle();
-
-  if (error) {
-    console.error(
-      "[authorPreferenceModel] Error al verificar preferencia:",
-      error
-    );
-    throw error;
-  }
-
-  return data?.id ?? null;
+  return findPreferenceId("autor", id_usuario, id_autor, "active");
 }
 
 async function findAuthorPreferenceIdIncludingDeleted(
   id_usuario: string,
   id_autor: number
 ): Promise<number | null> {
-  const adminClient = createAdminClient();
+  return findPreferenceId("autor", id_usuario, id_autor, "all");
+}
 
-  const { data, error } = await adminClient
+async function restoreAuthorPreference(existingId: number): Promise<number> {
+  const adminClient = createAdminClient();
+  const { data: updatedRows, error } = await adminClient
     .from("preferencia_autor")
+    .update({ deleted_at: null })
+    .eq("id", existingId)
     .select("id")
-    .eq("id_usuario", id_usuario)
-    .eq("id_autor", id_autor)
-    .limit(1)
-    .maybeSingle();
+    .single();
 
   if (error) {
     console.error(
-      "[authorPreferenceModel] Error al verificar preferencia (incluyendo eliminadas):",
+      "[authorPreferenceModel] Error al restaurar preferencia de autor:",
       error
     );
     throw error;
   }
 
-  return data?.id ?? null;
+  return updatedRows!.id;
 }
 
-export async function insertOrRestoreAuthorPreference(
-  data: InsertAuthorPreferencePayload
+async function insertAuthorPreference(
+  id_usuario: string,
+  id_autor: number
 ): Promise<number> {
   const adminClient = createAdminClient();
-
-  const existingId = await findAuthorPreferenceIdIncludingDeleted(
-    data.id_usuario,
-    data.id_autor
-  );
-
-  if (existingId !== null) {
-    const { data: updatedRows, error } = await adminClient
-      .from("preferencia_autor")
-      .update({ deleted_at: null })
-      .eq("id", existingId)
-      .select("id")
-      .single();
-
-    if (error) {
-      console.error(
-        "[authorPreferenceModel] Error al restaurar preferencia de autor:",
-        error
-      );
-      throw error;
-    }
-
-    return updatedRows!.id;
-  }
-
   const { data: resultData, error } = await adminClient
     .from("preferencia_autor")
-    .insert({
-      id_usuario: data.id_usuario,
-      id_autor: data.id_autor,
-    })
+    .insert({ id_usuario, id_autor })
     .select("id")
     .single();
 
@@ -142,20 +99,33 @@ export async function insertOrRestoreAuthorPreference(
       "[authorPreferenceModel] Error al insertar preferencia de autor:",
       error
     );
-
     if (error.code === "23505") {
       throw new Error("Este autor ya está en tus preferencias.");
     }
-
     throw error;
   }
 
   return resultData!.id;
 }
 
+export async function insertOrRestoreAuthorPreference(
+  data: InsertAuthorPreferencePayload
+): Promise<number> {
+  const existingId = await findAuthorPreferenceIdIncludingDeleted(
+    data.id_usuario,
+    data.id_autor
+  );
+
+  if (existingId !== null) {
+    return restoreAuthorPreference(existingId);
+  }
+
+  return insertAuthorPreference(data.id_usuario, data.id_autor);
+}
+
 async function ensureAuthorPreferenceExists(
   id_usuario: string,
-  id_autor: number,
+  id_autor: number
 ): Promise<number> {
   const id = await findAuthorPreferenceId(id_usuario, id_autor);
 
@@ -168,7 +138,7 @@ async function ensureAuthorPreferenceExists(
 
 export async function deleteAuthorPreference(
   id_usuario: string,
-  id_autor: number,
+  id_autor: number
 ): Promise<void> {
   const adminClient = createAdminClient();
 
@@ -184,7 +154,7 @@ export async function deleteAuthorPreference(
   if (error) {
     console.error(
       "[authorPreferenceModel] Error al eliminar preferencia de autor:",
-      error,
+      error
     );
     throw error;
   }

--- a/models/categoryModel.ts
+++ b/models/categoryModel.ts
@@ -281,3 +281,26 @@ export async function hasActiveBooksForCategory(
 
   return hasActiveBooks(data);
 }
+
+/**
+ * Verifica si existe una categoría activa por su ID.
+ * Helper para validaciones en services/rules.
+ */
+export async function checkCategoryExistsById(id: number): Promise<boolean> {
+  const adminClient = createAdminClient();
+
+  const { data, error } = await adminClient
+    .from("categoria")
+    .select("id")
+    .eq("id", id)
+    .is("deleted_at", null)
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    console.error("[categoryModel] Error al verificar existencia de categoría por ID:", error);
+    throw error;
+  }
+
+  return !!data;
+}

--- a/models/categoryPreferenceModel.ts
+++ b/models/categoryPreferenceModel.ts
@@ -1,0 +1,225 @@
+import { createAdminClient } from "@/lib/supabase/server";
+import type {
+  InsertCategoryPreferencePayload,
+  CategoryPreferenceCategorySummary,
+  CategoryPreferenceRow,
+  CategoryPreferenceWithDetails,
+} from "@/lib/types/categoryPreference";
+
+function isCategoryPreferenceCategorySummary(
+  value: unknown
+): value is CategoryPreferenceCategorySummary {
+  if (!value || typeof value !== "object") return false;
+
+  const candidate = value as Record<string, unknown>;
+
+  return typeof candidate.id === "number" && typeof candidate.nombre === "string";
+}
+
+function normalizeCategoryPreferenceCategory(
+  value: unknown
+): CategoryPreferenceCategorySummary | null {
+  if (!value) return null;
+
+  if (Array.isArray(value)) {
+    const first = value[0];
+    return isCategoryPreferenceCategorySummary(first) ? first : null;
+  }
+
+  return isCategoryPreferenceCategorySummary(value) ? value : null;
+}
+
+function normalizeCategoryPreferenceWithDetails(
+  row: CategoryPreferenceRow & { categoria?: unknown }
+): CategoryPreferenceWithDetails {
+  const { categoria, ...preference } = row;
+  return {
+    ...preference,
+    categoria: normalizeCategoryPreferenceCategory(categoria),
+  };
+}
+
+async function findCategoryPreferenceId(
+  id_usuario: string,
+  id_categoria: number
+): Promise<number | null> {
+  const adminClient = createAdminClient();
+
+  const { data, error } = await adminClient
+    .from("preferencia_categoria")
+    .select("id")
+    .eq("id_usuario", id_usuario)
+    .eq("id_categoria", id_categoria)
+    .is("deleted_at", null)
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    console.error(
+      "[categoryPreferenceModel] Error al verificar preferencia:",
+      error
+    );
+    throw error;
+  }
+
+  return data?.id ?? null;
+}
+
+async function findCategoryPreferenceIdIncludingDeleted(
+  id_usuario: string,
+  id_categoria: number
+): Promise<number | null> {
+  const adminClient = createAdminClient();
+
+  const { data, error } = await adminClient
+    .from("preferencia_categoria")
+    .select("id")
+    .eq("id_usuario", id_usuario)
+    .eq("id_categoria", id_categoria)
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    console.error(
+      "[categoryPreferenceModel] Error al verificar preferencia (incluyendo eliminados):",
+      error
+    );
+    throw error;
+  }
+
+  return data?.id ?? null;
+}
+
+export async function insertOrRestoreCategoryPreference(
+  data: InsertCategoryPreferencePayload
+): Promise<number> {
+  const adminClient = createAdminClient();
+
+  const existingId = await findCategoryPreferenceIdIncludingDeleted(
+    data.id_usuario,
+    data.id_categoria
+  );
+
+  if (existingId !== null) {
+    const { data: updatedRows, error } = await adminClient
+      .from("preferencia_categoria")
+      .update({ deleted_at: null })
+      .eq("id", existingId)
+      .is("deleted_at", null)
+      .select("id");
+
+    if (error) {
+      console.error(
+        "[categoryPreferenceModel] Error al restaurar preferencia de categoría:",
+        error
+      );
+      throw error;
+    }
+
+    if (!updatedRows || updatedRows.length === 0) {
+      throw new Error("La preferencia no existe o ya fue eliminada.");
+    }
+
+    return existingId;
+  }
+
+  const { data: insertData, error } = await adminClient
+    .from("preferencia_categoria")
+    .insert({
+      id_usuario: data.id_usuario,
+      id_categoria: data.id_categoria,
+    })
+    .select("id")
+    .single();
+
+  if (error) {
+    console.error(
+      "[categoryPreferenceModel] Error al insertar preferencia de categoría:",
+      error
+    );
+
+    if (error.code === "23505") {
+      throw new Error("Esta categoría ya está en tus preferencias.");
+    }
+
+    throw error;
+  }
+
+  return insertData!.id;
+}
+
+async function ensureCategoryPreferenceExists(
+  id_usuario: string,
+  id_categoria: number
+): Promise<number> {
+  const id = await findCategoryPreferenceId(id_usuario, id_categoria);
+
+  if (id === null) {
+    throw new Error("La preferencia no existe o ya fue eliminada.");
+  }
+
+  return id;
+}
+
+export async function deleteCategoryPreference(
+  id_usuario: string,
+  id_categoria: number
+): Promise<void> {
+  const adminClient = createAdminClient();
+
+  const existingId = await ensureCategoryPreferenceExists(id_usuario, id_categoria);
+
+  const { data: updatedRows, error } = await adminClient
+    .from("preferencia_categoria")
+    .update({ deleted_at: new Date().toISOString() })
+    .eq("id", existingId)
+    .is("deleted_at", null)
+    .select("id");
+
+  if (error) {
+    console.error(
+      "[categoryPreferenceModel] Error al eliminar preferencia de categoría:",
+      error
+    );
+    throw error;
+  }
+
+  if (!updatedRows || updatedRows.length === 0) {
+    throw new Error("La preferencia no existe o ya fue eliminada.");
+  }
+}
+
+export async function getCategoryPreferencesByUser(
+  id_usuario: string
+): Promise<CategoryPreferenceWithDetails[]> {
+  const adminClient = createAdminClient();
+
+  const { data, error } = await adminClient
+    .from("preferencia_categoria")
+    .select("*, categoria(id, nombre)")
+    .eq("id_usuario", id_usuario)
+    .is("deleted_at", null)
+    .order("id", { ascending: false });
+
+  if (error) {
+    console.error(
+      "[categoryPreferenceModel] Error al obtener preferencias de categoría:",
+      error
+    );
+    throw error;
+  }
+
+  return (data ?? []).map((row) =>
+    normalizeCategoryPreferenceWithDetails(
+      row as CategoryPreferenceRow & { categoria?: unknown }
+    )
+  );
+}
+
+export async function checkCategoryPreferenceExists(
+  id_usuario: string,
+  id_categoria: number
+): Promise<boolean> {
+  const id = await findCategoryPreferenceId(id_usuario, id_categoria);
+  return id !== null;
+}

--- a/models/categoryPreferenceModel.ts
+++ b/models/categoryPreferenceModel.ts
@@ -1,4 +1,5 @@
 import { createAdminClient } from "@/lib/supabase/server";
+import { findPreferenceId } from "@/lib/preferencias/preferenceQueryBuilder";
 import type {
   InsertCategoryPreferencePayload,
   CategoryPreferenceCategorySummary,
@@ -43,92 +44,47 @@ async function findCategoryPreferenceId(
   id_usuario: string,
   id_categoria: number
 ): Promise<number | null> {
-  const adminClient = createAdminClient();
-
-  const { data, error } = await adminClient
-    .from("preferencia_categoria")
-    .select("id")
-    .eq("id_usuario", id_usuario)
-    .eq("id_categoria", id_categoria)
-    .is("deleted_at", null)
-    .limit(1)
-    .maybeSingle();
-
-  if (error) {
-    console.error(
-      "[categoryPreferenceModel] Error al verificar preferencia:",
-      error
-    );
-    throw error;
-  }
-
-  return data?.id ?? null;
+  return findPreferenceId("categoria", id_usuario, id_categoria, "active");
 }
 
 async function findCategoryPreferenceIdIncludingDeleted(
   id_usuario: string,
   id_categoria: number
 ): Promise<number | null> {
-  const adminClient = createAdminClient();
+  return findPreferenceId("categoria", id_usuario, id_categoria, "all");
+}
 
-  const { data, error } = await adminClient
+async function restoreCategoryPreference(existingId: number): Promise<number> {
+  const adminClient = createAdminClient();
+  const { data: updatedRows, error } = await adminClient
     .from("preferencia_categoria")
-    .select("id")
-    .eq("id_usuario", id_usuario)
-    .eq("id_categoria", id_categoria)
-    .limit(1)
-    .maybeSingle();
+    .update({ deleted_at: null })
+    .eq("id", existingId)
+    .select("id");
 
   if (error) {
     console.error(
-      "[categoryPreferenceModel] Error al verificar preferencia (incluyendo eliminados):",
+      "[categoryPreferenceModel] Error al restaurar preferencia de categoría:",
       error
     );
     throw error;
   }
 
-  return data?.id ?? null;
-}
-
-export async function insertOrRestoreCategoryPreference(
-  data: InsertCategoryPreferencePayload
-): Promise<number> {
-  const adminClient = createAdminClient();
-
-  const existingId = await findCategoryPreferenceIdIncludingDeleted(
-    data.id_usuario,
-    data.id_categoria
-  );
-
-  if (existingId !== null) {
-    const { data: updatedRows, error } = await adminClient
-      .from("preferencia_categoria")
-      .update({ deleted_at: null })
-      .eq("id", existingId)
-      .is("deleted_at", null)
-      .select("id");
-
-    if (error) {
-      console.error(
-        "[categoryPreferenceModel] Error al restaurar preferencia de categoría:",
-        error
-      );
-      throw error;
-    }
-
-    if (!updatedRows || updatedRows.length === 0) {
-      throw new Error("La preferencia no existe o ya fue eliminada.");
-    }
-
-    return existingId;
+  if (!updatedRows || updatedRows.length === 0) {
+    throw new Error("La preferencia no existe o ya fue eliminada.");
   }
 
+  return existingId;
+}
+
+async function insertCategoryPreference(
+  id_usuario: string,
+  id_categoria: number
+): Promise<number> {
+  const adminClient = createAdminClient();
   const { data: insertData, error } = await adminClient
     .from("preferencia_categoria")
-    .insert({
-      id_usuario: data.id_usuario,
-      id_categoria: data.id_categoria,
-    })
+    .insert({ id_usuario, id_categoria })
     .select("id")
     .single();
 
@@ -137,15 +93,28 @@ export async function insertOrRestoreCategoryPreference(
       "[categoryPreferenceModel] Error al insertar preferencia de categoría:",
       error
     );
-
     if (error.code === "23505") {
       throw new Error("Esta categoría ya está en tus preferencias.");
     }
-
     throw error;
   }
 
   return insertData!.id;
+}
+
+export async function insertOrRestoreCategoryPreference(
+  data: InsertCategoryPreferencePayload
+): Promise<number> {
+  const existingId = await findCategoryPreferenceIdIncludingDeleted(
+    data.id_usuario,
+    data.id_categoria
+  );
+
+  if (existingId !== null) {
+    return restoreCategoryPreference(existingId);
+  }
+
+  return insertCategoryPreference(data.id_usuario, data.id_categoria);
 }
 
 async function ensureCategoryPreferenceExists(

--- a/services/preferencias/preferenciasService.ts
+++ b/services/preferencias/preferenciasService.ts
@@ -2,13 +2,20 @@ import { requireClientRole } from "@/lib/validations/server-auth";
 import { getCurrentUser } from "@/models/authModel";
 import { getErrorMessage } from "@/lib/services/errors";
 import {
-  insertAuthorPreference,
+  insertOrRestoreAuthorPreference,
   deleteAuthorPreference,
   getAuthorPreferencesByUser,
 } from "@/models/authorPreferenceModel";
 import {
+  insertOrRestoreCategoryPreference,
+  deleteCategoryPreference,
+  getCategoryPreferencesByUser,
+} from "@/models/categoryPreferenceModel";
+import {
   checkAuthorPreferenceNotDuplicate,
   checkPreferenceAuthorExists,
+  checkCategoryPreferenceNotDuplicate,
+  checkPreferenceCategoryExists,
 } from "@/services/rules/preferenciasRules";
 import type {
   AddAuthorPreferenceInput,
@@ -16,6 +23,12 @@ import type {
   AuthorPreferenceDataResponse,
   AuthorPreferenceWithDetails,
 } from "@/lib/types/authorPreference";
+import type {
+  AddCategoryPreferenceInput,
+  CategoryPreferenceActionResponse,
+  CategoryPreferenceDataResponse,
+  CategoryPreferenceWithDetails,
+} from "@/lib/types/categoryPreference";
 
 export async function addAuthorPreference(
   data: AddAuthorPreferenceInput
@@ -36,7 +49,34 @@ export async function addAuthorPreference(
 
   let insertedId: number;
   try {
-    insertedId = await insertAuthorPreference({ id_usuario: user.id, id_autor: data.id_autor });
+    insertedId = await insertOrRestoreAuthorPreference({ id_usuario: user.id, id_autor: data.id_autor });
+  } catch (error) {
+    return { success: false, errors: { form: getErrorMessage(error) }, message: getErrorMessage(error) };
+  }
+
+  return { success: true, id: insertedId };
+}
+
+export async function addCategoryPreference(
+  data: AddCategoryPreferenceInput
+): Promise<CategoryPreferenceActionResponse> {
+  const roleCheck = await requireClientRole();
+  if (!roleCheck.success) return roleCheck;
+
+  const user = await getCurrentUser();
+  if (!user) {
+    return { success: false, errors: { form: "No hay sesión activa." }, message: "No hay sesión activa." };
+  }
+
+  const precheckDuplicate = await checkCategoryPreferenceNotDuplicate(user.id, data.id_categoria);
+  if (precheckDuplicate) return precheckDuplicate;
+
+  const precheckCategory = await checkPreferenceCategoryExists(data.id_categoria);
+  if (precheckCategory) return precheckCategory;
+
+  let insertedId: number;
+  try {
+    insertedId = await insertOrRestoreCategoryPreference({ id_usuario: user.id, id_categoria: data.id_categoria });
   } catch (error) {
     return { success: false, errors: { form: getErrorMessage(error) }, message: getErrorMessage(error) };
   }
@@ -64,6 +104,26 @@ export async function removeAuthorPreference(
   return { success: true };
 }
 
+export async function removeCategoryPreference(
+  id_categoria: number
+): Promise<CategoryPreferenceActionResponse> {
+  const roleCheck = await requireClientRole();
+  if (!roleCheck.success) return roleCheck;
+
+  const user = await getCurrentUser();
+  if (!user) {
+    return { success: false, errors: { form: "No hay sesión activa." }, message: "No hay sesión activa." };
+  }
+
+  try {
+    await deleteCategoryPreference(user.id, id_categoria);
+  } catch (error) {
+    return { success: false, errors: { form: getErrorMessage(error) }, message: getErrorMessage(error) };
+  }
+
+  return { success: true };
+}
+
 export async function getMyAuthorPreferences(): Promise<AuthorPreferenceDataResponse> {
   const roleCheck = await requireClientRole();
   if (!roleCheck.success) return { success: false, errors: { form: roleCheck.message ?? "No tienes permisos." }, message: roleCheck.message };
@@ -76,6 +136,25 @@ export async function getMyAuthorPreferences(): Promise<AuthorPreferenceDataResp
   let preferences: AuthorPreferenceWithDetails[];
   try {
     preferences = await getAuthorPreferencesByUser(user.id);
+  } catch (error) {
+    return { success: false, errors: { form: getErrorMessage(error) }, message: getErrorMessage(error) };
+  }
+
+  return { success: true, data: preferences };
+}
+
+export async function getMyCategoryPreferences(): Promise<CategoryPreferenceDataResponse> {
+  const roleCheck = await requireClientRole();
+  if (!roleCheck.success) return { success: false, errors: { form: roleCheck.message ?? "No tienes permisos." }, message: roleCheck.message };
+
+  const user = await getCurrentUser();
+  if (!user) {
+    return { success: false, errors: { form: "No hay sesión activa." } };
+  }
+
+  let preferences: CategoryPreferenceWithDetails[];
+  try {
+    preferences = await getCategoryPreferencesByUser(user.id);
   } catch (error) {
     return { success: false, errors: { form: getErrorMessage(error) }, message: getErrorMessage(error) };
   }

--- a/services/preferencias/preferenciasService.ts
+++ b/services/preferencias/preferenciasService.ts
@@ -1,5 +1,4 @@
-import { requireClientRole } from "@/lib/validations/server-auth";
-import { getCurrentUser } from "@/models/authModel";
+import { getAuthenticatedUser } from "@/lib/preferencias/preferenciaServiceUtils";
 import { getErrorMessage } from "@/lib/services/errors";
 import {
   insertOrRestoreAuthorPreference,
@@ -29,17 +28,15 @@ import type {
   CategoryPreferenceDataResponse,
   CategoryPreferenceWithDetails,
 } from "@/lib/types/categoryPreference";
+import type { User } from "@supabase/supabase-js";
 
 export async function addAuthorPreference(
   data: AddAuthorPreferenceInput
 ): Promise<AuthorPreferenceActionResponse> {
-  const roleCheck = await requireClientRole();
-  if (!roleCheck.success) return roleCheck;
+  const auth = await getAuthenticatedUser();
+  if (!auth.success) return auth;
 
-  const user = await getCurrentUser();
-  if (!user) {
-    return { success: false, errors: { form: "No hay sesión activa." }, message: "No hay sesión activa." };
-  }
+  const user = (auth as { success: true; user: User }).user;
 
   const precheckDuplicate = await checkAuthorPreferenceNotDuplicate(user.id, data.id_autor);
   if (precheckDuplicate) return precheckDuplicate;
@@ -60,13 +57,10 @@ export async function addAuthorPreference(
 export async function addCategoryPreference(
   data: AddCategoryPreferenceInput
 ): Promise<CategoryPreferenceActionResponse> {
-  const roleCheck = await requireClientRole();
-  if (!roleCheck.success) return roleCheck;
+  const auth = await getAuthenticatedUser();
+  if (!auth.success) return auth;
 
-  const user = await getCurrentUser();
-  if (!user) {
-    return { success: false, errors: { form: "No hay sesión activa." }, message: "No hay sesión activa." };
-  }
+  const user = (auth as { success: true; user: User }).user;
 
   const precheckDuplicate = await checkCategoryPreferenceNotDuplicate(user.id, data.id_categoria);
   if (precheckDuplicate) return precheckDuplicate;
@@ -87,13 +81,10 @@ export async function addCategoryPreference(
 export async function removeAuthorPreference(
   id_autor: number
 ): Promise<AuthorPreferenceActionResponse> {
-  const roleCheck = await requireClientRole();
-  if (!roleCheck.success) return roleCheck;
+  const auth = await getAuthenticatedUser();
+  if (!auth.success) return auth;
 
-  const user = await getCurrentUser();
-  if (!user) {
-    return { success: false, errors: { form: "No hay sesión activa." }, message: "No hay sesión activa." };
-  }
+  const user = (auth as { success: true; user: User }).user;
 
   try {
     await deleteAuthorPreference(user.id, id_autor);
@@ -107,13 +98,10 @@ export async function removeAuthorPreference(
 export async function removeCategoryPreference(
   id_categoria: number
 ): Promise<CategoryPreferenceActionResponse> {
-  const roleCheck = await requireClientRole();
-  if (!roleCheck.success) return roleCheck;
+  const auth = await getAuthenticatedUser();
+  if (!auth.success) return auth;
 
-  const user = await getCurrentUser();
-  if (!user) {
-    return { success: false, errors: { form: "No hay sesión activa." }, message: "No hay sesión activa." };
-  }
+  const user = (auth as { success: true; user: User }).user;
 
   try {
     await deleteCategoryPreference(user.id, id_categoria);
@@ -125,13 +113,10 @@ export async function removeCategoryPreference(
 }
 
 export async function getMyAuthorPreferences(): Promise<AuthorPreferenceDataResponse> {
-  const roleCheck = await requireClientRole();
-  if (!roleCheck.success) return { success: false, errors: { form: roleCheck.message ?? "No tienes permisos." }, message: roleCheck.message };
+  const auth = await getAuthenticatedUser();
+  if (!auth.success) return { success: false, errors: { form: auth.message ?? "No tienes permisos." }, message: auth.message };
 
-  const user = await getCurrentUser();
-  if (!user) {
-    return { success: false, errors: { form: "No hay sesión activa." } };
-  }
+  const user = (auth as { success: true; user: User }).user;
 
   let preferences: AuthorPreferenceWithDetails[];
   try {
@@ -144,13 +129,10 @@ export async function getMyAuthorPreferences(): Promise<AuthorPreferenceDataResp
 }
 
 export async function getMyCategoryPreferences(): Promise<CategoryPreferenceDataResponse> {
-  const roleCheck = await requireClientRole();
-  if (!roleCheck.success) return { success: false, errors: { form: roleCheck.message ?? "No tienes permisos." }, message: roleCheck.message };
+  const auth = await getAuthenticatedUser();
+  if (!auth.success) return { success: false, errors: { form: auth.message ?? "No tienes permisos." }, message: auth.message };
 
-  const user = await getCurrentUser();
-  if (!user) {
-    return { success: false, errors: { form: "No hay sesión activa." } };
-  }
+  const user = (auth as { success: true; user: User }).user;
 
   let preferences: CategoryPreferenceWithDetails[];
   try {

--- a/services/rules/preferenciasRules.ts
+++ b/services/rules/preferenciasRules.ts
@@ -2,6 +2,9 @@ import { checkAuthorPreferenceExists } from "@/models/authorPreferenceModel";
 import { checkAuthorExistsById } from "@/models/authorModel";
 import { getErrorMessage } from "@/lib/services/errors";
 import type { AuthorPreferenceActionResponse } from "@/lib/types/authorPreference";
+import { checkCategoryPreferenceExists } from "@/models/categoryPreferenceModel";
+import { checkCategoryExistsById } from "@/models/categoryModel";
+import type { CategoryPreferenceActionResponse } from "@/lib/types/categoryPreference";
 
 export async function checkAuthorPreferenceNotDuplicate(
   id_usuario: string,
@@ -22,6 +25,53 @@ export async function checkAuthorPreferenceNotDuplicate(
       success: false,
       errors: { form: "Ya tienes este autor en tus preferencias." },
       message: "Ya tienes este autor en tus preferencias.",
+    };
+  }
+  return null;
+}
+
+export async function checkCategoryPreferenceNotDuplicate(
+  id_usuario: string,
+  id_categoria: number
+): Promise<CategoryPreferenceActionResponse | null> {
+  let exists: boolean;
+  try {
+    exists = await checkCategoryPreferenceExists(id_usuario, id_categoria);
+  } catch (error) {
+    return {
+      success: false,
+      errors: { form: getErrorMessage(error) },
+      message: getErrorMessage(error),
+    };
+  }
+  if (exists) {
+    return {
+      success: false,
+      errors: { form: "Ya tienes esta categoría en tus preferencias." },
+      message: "Ya tienes esta categoría en tus preferencias.",
+    };
+  }
+  return null;
+}
+
+export async function checkPreferenceCategoryExists(
+  id_categoria: number
+): Promise<CategoryPreferenceActionResponse | null> {
+  let exists: boolean;
+  try {
+    exists = await checkCategoryExistsById(id_categoria);
+  } catch (error) {
+    return {
+      success: false,
+      errors: { form: getErrorMessage(error) },
+      message: getErrorMessage(error),
+    };
+  }
+  if (!exists) {
+    return {
+      success: false,
+      errors: { form: "La categoría seleccionada no existe." },
+      message: "La categoría seleccionada no existe.",
     };
   }
   return null;


### PR DESCRIPTION
…n lógica de restauración

- Crear lib/types/preferencia.ts con tipos genéricos PreferenceActionResponse y PreferenceDataResponse
- Crear lib/types/categoryPreference.ts con tipos para preferencias de categoría
- Actualizar lib/types/authorPreference.ts para usar PreferenceActionResponse genérico
- Agregar checkCategoryExistsById a models/categoryModel.ts
- Crear models/categoryPreferenceModel.ts con patrón insert-or-restore
- Actualizar models/authorPreferenceModel.ts: insertAuthorPreference → insertOrRestoreAuthorPreference con lógica de restaurar preferencias previamente eliminadas en lugar de crear nuevas
- Extender services/rules/preferenciasRules.ts con funciones de validación para categorías
- Actualizar services/preferencias/preferenciasService.ts con métodos de categoría interleavados