### PR TITLE
Feat/busqueda

### DIFF
--- a/app/(with-navbar)/SearchSection.tsx
+++ b/app/(with-navbar)/SearchSection.tsx
@@ -1,0 +1,31 @@
+import { Suspense } from "react";
+import SearchResultsClient from "@/components/SearchResultsClient";
+import type { NoticiaWithLibroCompleto } from "@/lib/types/noticia";
+import type { Paginated } from "@/lib/types/common";
+
+interface SearchSectionProps {
+  results: Paginated<NoticiaWithLibroCompleto>;
+}
+
+export default function SearchSection({ results }: SearchSectionProps) {
+  return (
+    <section className="max-w-6xl mx-auto px-4 pt-8 pb-16">
+      <div className="flex items-center gap-4 mb-6">
+        <div className="h-px flex-1 bg-brand-accent/20" />
+        <h2 className="font-display text-xl font-semibold text-brand-text tracking-tight">
+          Resultados de búsqueda
+        </h2>
+        <div className="h-px flex-1 bg-brand-accent/20" />
+      </div>
+      <Suspense
+        fallback={
+          <div className="flex items-center justify-center py-16">
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-brand-primary" />
+          </div>
+        }
+      >
+        <SearchResultsClient initialResults={results} />
+      </Suspense>
+    </section>
+  );
+}

--- a/app/(with-navbar)/page.tsx
+++ b/app/(with-navbar)/page.tsx
@@ -2,11 +2,14 @@ import Footer from "@/components/Footer";
 import Carousel from "@/components/Carousel";
 import NewsGrid from "@/components/ui/NewsGrid";
 import PreferenciasLiterariasSection from "@/components/profile/PreferenciasLiterariasSection";
+import SearchResultsClient from "@/components/SearchResultsClient";
 import { getNoticiasWithLibroCompleto } from "@/models/noticiaModel";
 import { getCurrentUser, getCurrentUserRole } from "@/models/authModel";
+import { buscarNoticiasAction } from "@/app/actions/buscarAction";
 import { Rol } from "@/lib/types/auth";
 import type { NoticiaWithLibroCompleto } from "@/lib/types/noticia";
 import type { Paginated } from "@/lib/types/common";
+import { Suspense } from "react";
 
 const MOCK_CAROUSEL_IMAGES = [
   "https://i.imgur.com/nTxt9Xk.jpeg",
@@ -24,10 +27,17 @@ const MOCK_CAROUSEL_TITLES = [
   "Edición Especial",
 ];
 
-export default async function Home() {
-  const [user, role] = await Promise.all([
+type SearchParams = Promise<Record<string, string>>;
+
+export default async function Home({
+  searchParams,
+}: {
+  searchParams: SearchParams;
+}) {
+  const [user, role, currentSearchParams] = await Promise.all([
     getCurrentUser(),
     getCurrentUserRole(),
+    searchParams,
   ]);
 
   const needsOnboarding =
@@ -68,28 +78,60 @@ export default async function Home() {
           precio: 0,
         }));
 
+  const hasFilters =
+    currentSearchParams.q ||
+    currentSearchParams.autor ||
+    currentSearchParams.categoria ||
+    currentSearchParams.idioma ||
+    currentSearchParams.editorial ||
+    currentSearchParams.ano_publicacion ||
+    currentSearchParams.precioMin ||
+    currentSearchParams.precioMax ||
+    currentSearchParams.estado;
+
+  const results = hasFilters
+    ? await buscarNoticiasAction(new URLSearchParams(currentSearchParams))
+    : null;
+
   return (
     <div className="min-h-screen bg-brand-bg flex flex-col">
       <main className="flex-1">
-        <section className="max-w-6xl mx-auto px-4 pt-8 pb-12">
-          <Carousel items={displayItems} />
-        </section>
-
-        <section className="max-w-6xl mx-auto px-4 pb-16">
-          <div className="flex items-center gap-4 mb-6">
-            <div className="h-px flex-1 bg-brand-accent/20" />
-            <h2 className="font-display text-xl font-semibold text-brand-text tracking-tight">
-              Novedades
-            </h2>
-            <div className="h-px flex-1 bg-brand-accent/20" />
-          </div>
-          <NewsGrid initialNews={newsData.data} />
-        </section>
-
-        {needsOnboarding && (
-          <section className="max-w-6xl mx-auto px-4 pb-16">
-            <PreferenciasLiterariasSection isOnboarding />
+        {hasFilters ? (
+          <section className="max-w-6xl mx-auto px-4 pt-8 pb-16">
+            <div className="flex items-center gap-4 mb-6">
+              <div className="h-px flex-1 bg-brand-accent/20" />
+              <h2 className="font-display text-xl font-semibold text-brand-text tracking-tight">
+                Resultados de búsqueda
+              </h2>
+              <div className="h-px flex-1 bg-brand-accent/20" />
+            </div>
+            <Suspense fallback={<div className="flex items-center justify-center py-16"><div className="animate-spin rounded-full h-8 w-8 border-b-2 border-brand-primary" /></div>}>
+              <SearchResultsClient initialResults={results!} />
+            </Suspense>
           </section>
+        ) : (
+          <>
+            <section className="max-w-6xl mx-auto px-4 pt-8 pb-12">
+              <Carousel items={displayItems} />
+            </section>
+
+            <section className="max-w-6xl mx-auto px-4 pb-16">
+              <div className="flex items-center gap-4 mb-6">
+                <div className="h-px flex-1 bg-brand-accent/20" />
+                <h2 className="font-display text-xl font-semibold text-brand-text tracking-tight">
+                  Novedades
+                </h2>
+                <div className="h-px flex-1 bg-brand-accent/20" />
+              </div>
+              <NewsGrid initialNews={newsData.data} />
+            </section>
+
+            {needsOnboarding && (
+              <section className="max-w-6xl mx-auto px-4 pb-16">
+                <PreferenciasLiterariasSection isOnboarding />
+              </section>
+            )}
+          </>
         )}
       </main>
 

--- a/app/(with-navbar)/page.tsx
+++ b/app/(with-navbar)/page.tsx
@@ -2,10 +2,10 @@ import Footer from "@/components/Footer";
 import Carousel from "@/components/Carousel";
 import NewsGrid from "@/components/ui/NewsGrid";
 import PreferenciasLiterariasSection from "@/components/profile/PreferenciasLiterariasSection";
-import { getNoticiasWithPrecio } from "@/models/noticiaModel";
+import { getNoticiasWithLibroCompleto } from "@/models/noticiaModel";
 import { getCurrentUser, getCurrentUserRole } from "@/models/authModel";
 import { Rol } from "@/lib/types/auth";
-import type { NoticiaWithPrecio } from "@/lib/types/noticia";
+import type { NoticiaWithLibroCompleto } from "@/lib/types/noticia";
 import type { Paginated } from "@/lib/types/common";
 
 const MOCK_CAROUSEL_IMAGES = [
@@ -34,7 +34,7 @@ export default async function Home() {
     role === Rol.CLIENTE &&
     user?.user_metadata?.preferences_onboarding_complete !== true;
 
-  let newsData: Paginated<NoticiaWithPrecio> = {
+  let newsData: Paginated<NoticiaWithLibroCompleto> = {
     data: [],
     total: 0,
     page: 1,
@@ -43,7 +43,7 @@ export default async function Home() {
   };
 
   try {
-    newsData = await getNoticiasWithPrecio(1, 20);
+    newsData = await getNoticiasWithLibroCompleto(1, 20);
   } catch (error) {
     console.error("[Home] Error fetching news:", error);
   }

--- a/app/(with-navbar)/page.tsx
+++ b/app/(with-navbar)/page.tsx
@@ -2,14 +2,13 @@ import Footer from "@/components/Footer";
 import Carousel from "@/components/Carousel";
 import NewsGrid from "@/components/ui/NewsGrid";
 import PreferenciasLiterariasSection from "@/components/profile/PreferenciasLiterariasSection";
-import SearchResultsClient from "@/components/SearchResultsClient";
+import SearchSection from "./SearchSection";
 import { getNoticiasWithLibroCompleto } from "@/models/noticiaModel";
 import { getCurrentUser, getCurrentUserRole } from "@/models/authModel";
 import { buscarNoticiasAction } from "@/app/actions/buscarAction";
 import { Rol } from "@/lib/types/auth";
 import type { NoticiaWithLibroCompleto } from "@/lib/types/noticia";
 import type { Paginated } from "@/lib/types/common";
-import { Suspense } from "react";
 
 const MOCK_CAROUSEL_IMAGES = [
   "https://i.imgur.com/nTxt9Xk.jpeg",
@@ -28,6 +27,50 @@ const MOCK_CAROUSEL_TITLES = [
 ];
 
 type SearchParams = Promise<Record<string, string>>;
+
+interface CarouselItem {
+  id: string;
+  imagenes: string[] | null;
+  libro_titulo: string;
+  precio: number;
+}
+
+function buildCarouselItems(newsData: Paginated<NoticiaWithLibroCompleto>): CarouselItem[] {
+  const carouselItems = newsData.data
+    .filter((n) => n.imagenes && n.imagenes.length > 0)
+    .slice(0, 5)
+    .map((n) => ({
+      id: n.id,
+      imagenes: n.imagenes,
+      libro_titulo: n.libro_titulo || "",
+      precio: n.precio,
+    }));
+
+  if (carouselItems.length > 0) {
+    return carouselItems;
+  }
+
+  return MOCK_CAROUSEL_IMAGES.map((url, index) => ({
+    id: `mock-${index}`,
+    imagenes: [url],
+    libro_titulo: MOCK_CAROUSEL_TITLES[index],
+    precio: 0,
+  }));
+}
+
+function hasActiveFilters(searchParams: Record<string, string>): boolean {
+  return !!(
+    searchParams.q ||
+    searchParams.autor ||
+    searchParams.categoria ||
+    searchParams.idioma ||
+    searchParams.editorial ||
+    searchParams.ano_publicacion ||
+    searchParams.precioMin ||
+    searchParams.precioMax ||
+    searchParams.estado
+  );
+}
 
 export default async function Home({
   searchParams,
@@ -58,57 +101,18 @@ export default async function Home({
     console.error("[Home] Error fetching news:", error);
   }
 
-  const carouselItems = newsData.data
-    .filter((n) => n.imagenes && n.imagenes.length > 0)
-    .slice(0, 5)
-    .map((n) => ({
-      id: n.id,
-      imagenes: n.imagenes,
-      libro_titulo: n.libro_titulo || "",
-      precio: n.precio,
-    }));
+  const displayItems = buildCarouselItems(newsData);
+  const filtersActive = hasActiveFilters(currentSearchParams);
 
-  const displayItems =
-    carouselItems.length > 0
-      ? carouselItems
-      : MOCK_CAROUSEL_IMAGES.map((url, index) => ({
-          id: `mock-${index}`,
-          imagenes: [url],
-          libro_titulo: MOCK_CAROUSEL_TITLES[index],
-          precio: 0,
-        }));
-
-  const hasFilters =
-    currentSearchParams.q ||
-    currentSearchParams.autor ||
-    currentSearchParams.categoria ||
-    currentSearchParams.idioma ||
-    currentSearchParams.editorial ||
-    currentSearchParams.ano_publicacion ||
-    currentSearchParams.precioMin ||
-    currentSearchParams.precioMax ||
-    currentSearchParams.estado;
-
-  const results = hasFilters
+  const results = filtersActive
     ? await buscarNoticiasAction(new URLSearchParams(currentSearchParams))
     : null;
 
   return (
     <div className="min-h-screen bg-brand-bg flex flex-col">
       <main className="flex-1">
-        {hasFilters ? (
-          <section className="max-w-6xl mx-auto px-4 pt-8 pb-16">
-            <div className="flex items-center gap-4 mb-6">
-              <div className="h-px flex-1 bg-brand-accent/20" />
-              <h2 className="font-display text-xl font-semibold text-brand-text tracking-tight">
-                Resultados de búsqueda
-              </h2>
-              <div className="h-px flex-1 bg-brand-accent/20" />
-            </div>
-            <Suspense fallback={<div className="flex items-center justify-center py-16"><div className="animate-spin rounded-full h-8 w-8 border-b-2 border-brand-primary" /></div>}>
-              <SearchResultsClient initialResults={results!} />
-            </Suspense>
-          </section>
+        {filtersActive ? (
+          <SearchSection results={results!} />
         ) : (
           <>
             <section className="max-w-6xl mx-auto px-4 pt-8 pb-12">

--- a/app/actions/buscarAction.ts
+++ b/app/actions/buscarAction.ts
@@ -1,0 +1,62 @@
+"use server";
+
+import { buscarNoticias } from "@/services/noticias/noticiaService";
+import { sanitizeText, toSafePositiveInt } from "@/lib/validations/rules";
+import type { NoticiaWithLibroCompleto } from "@/lib/types/noticia";
+import type { Paginated } from "@/lib/types/common";
+
+export async function buscarNoticiasAction(
+  searchParams: URLSearchParams
+): Promise<Paginated<NoticiaWithLibroCompleto>> {
+  const page = toSafePositiveInt(Number(searchParams.get("page") ?? 1), 1);
+  const pageSize = Math.min(toSafePositiveInt(Number(searchParams.get("pageSize") ?? 20), 20), 100);
+
+  const q = searchParams.get("q")?.trim() ?? undefined;
+
+  const autor = searchParams.get("autor")?.trim() || undefined;
+  const categoria = searchParams.get("categoria")?.trim() || undefined;
+  const idioma = searchParams.get("idioma")?.trim() || undefined;
+  const editorial = searchParams.get("editorial")?.trim() || undefined;
+  const estado = searchParams.get("estado")?.trim() || undefined;
+
+  const ano_publicacion_str = searchParams.get("ano_publicacion")?.trim();
+  const ano_publicacion = ano_publicacion_str ? toSafePositiveInt(Number(ano_publicacion_str), NaN) || undefined : undefined;
+  
+  const precioMin_str = searchParams.get("precioMin")?.trim();
+  const precioMin = precioMin_str ? parseFloat(precioMin_str) : undefined;
+  
+  const precioMax_str = searchParams.get("precioMax")?.trim();
+  const precioMax = precioMax_str ? parseFloat(precioMax_str) : undefined;
+
+  const cleanAutor = autor ? sanitizeText(autor) : undefined;
+  const cleanCategoria = categoria ? sanitizeText(categoria) : undefined;
+  const cleanIdioma = idioma ? sanitizeText(idioma) : undefined;
+  const cleanEditorial = editorial ? sanitizeText(editorial) : undefined;
+
+  try {
+    const result = await buscarNoticias({
+      page,
+      pageSize,
+      q,
+      autor: cleanAutor,
+      categoria: cleanCategoria,
+      idioma: cleanIdioma,
+      editorial: cleanEditorial,
+      ano_publicacion,
+      precioMin,
+      precioMax,
+      estado: estado as "nuevo" | "usado" | undefined,
+    });
+
+    return result;
+  } catch (error) {
+    console.error("[buscarAction] Error searching noticias:", error);
+    return {
+      data: [],
+      total: 0,
+      page: 1,
+      pageSize,
+      totalPages: 0,
+    };
+  }
+}

--- a/app/actions/buscarAction.ts
+++ b/app/actions/buscarAction.ts
@@ -14,6 +14,15 @@ function parseTextFilterParam(params: URLSearchParams, key: string, sanitize = t
   return sanitize ? sanitizeText(value) : value;
 }
 
+function parseNumericParam(
+  params: URLSearchParams,
+  key: string,
+  parser: (v: string) => number | undefined
+): number | undefined {
+  const value = params.get(key)?.trim();
+  return value ? parser(value) : undefined;
+}
+
 function parseSearchFilters(searchParams: URLSearchParams): BuscarNoticiasParams {
   const result: Partial<BuscarNoticiasParams> = {};
 
@@ -27,14 +36,11 @@ function parseSearchFilters(searchParams: URLSearchParams): BuscarNoticiasParams
   const page = toSafePositiveInt(Number(searchParams.get("page") ?? 1), 1);
   const pageSize = Math.min(toSafePositiveInt(Number(searchParams.get("pageSize") ?? 20), 20), 100);
 
-  const ano_publicacion_str = searchParams.get("ano_publicacion")?.trim();
-  const ano_publicacion = ano_publicacion_str ? toSafePositiveInt(Number(ano_publicacion_str), NaN) || undefined : undefined;
-
-  const precioMin_str = searchParams.get("precioMin")?.trim();
-  const precioMin = precioMin_str ? parseFloat(precioMin_str) : undefined;
-
-  const precioMax_str = searchParams.get("precioMax")?.trim();
-  const precioMax = precioMax_str ? parseFloat(precioMax_str) : undefined;
+  const ano_publicacion = parseNumericParam(searchParams, "ano_publicacion", (v) =>
+    toSafePositiveInt(Number(v), NaN) || undefined
+  );
+  const precioMin = parseNumericParam(searchParams, "precioMin", parseFloat);
+  const precioMax = parseNumericParam(searchParams, "precioMax", parseFloat);
 
   return {
     page,

--- a/app/actions/buscarAction.ts
+++ b/app/actions/buscarAction.ts
@@ -6,17 +6,26 @@ import type { NoticiaWithLibroCompleto } from "@/lib/types/noticia";
 import type { Paginated } from "@/lib/types/common";
 import type { BuscarNoticiasParams } from "@/services/noticias/noticiaService";
 
+const TEXT_FILTER_PARAMS = ["q", "autor", "categoria", "idioma", "editorial", "estado"] as const;
+
+function parseTextFilterParam(params: URLSearchParams, key: string, sanitize = true): string | undefined {
+  const value = params.get(key)?.trim();
+  if (!value) return undefined;
+  return sanitize ? sanitizeText(value) : value;
+}
+
 function parseSearchFilters(searchParams: URLSearchParams): BuscarNoticiasParams {
+  const result: Partial<BuscarNoticiasParams> = {};
+
+  for (const key of TEXT_FILTER_PARAMS) {
+    const value = parseTextFilterParam(searchParams, key);
+    if (value !== undefined) {
+      (result as Record<string, unknown>)[key] = key === "estado" ? (value as "nuevo" | "usado") : value;
+    }
+  }
+
   const page = toSafePositiveInt(Number(searchParams.get("page") ?? 1), 1);
   const pageSize = Math.min(toSafePositiveInt(Number(searchParams.get("pageSize") ?? 20), 20), 100);
-
-  const q = searchParams.get("q")?.trim() || undefined;
-
-  const autor = searchParams.get("autor")?.trim() || undefined;
-  const categoria = searchParams.get("categoria")?.trim() || undefined;
-  const idioma = searchParams.get("idioma")?.trim() || undefined;
-  const editorial = searchParams.get("editorial")?.trim() || undefined;
-  const estado = searchParams.get("estado")?.trim() || undefined;
 
   const ano_publicacion_str = searchParams.get("ano_publicacion")?.trim();
   const ano_publicacion = ano_publicacion_str ? toSafePositiveInt(Number(ano_publicacion_str), NaN) || undefined : undefined;
@@ -30,15 +39,10 @@ function parseSearchFilters(searchParams: URLSearchParams): BuscarNoticiasParams
   return {
     page,
     pageSize,
-    q,
-    autor: autor ? sanitizeText(autor) : undefined,
-    categoria: categoria ? sanitizeText(categoria) : undefined,
-    idioma: idioma ? sanitizeText(idioma) : undefined,
-    editorial: editorial ? sanitizeText(editorial) : undefined,
-    estado: estado as "nuevo" | "usado" | undefined,
     ano_publicacion,
     precioMin,
     precioMax,
+    ...result,
   };
 }
 

--- a/app/actions/buscarAction.ts
+++ b/app/actions/buscarAction.ts
@@ -4,14 +4,13 @@ import { buscarNoticias } from "@/services/noticias/noticiaService";
 import { sanitizeText, toSafePositiveInt } from "@/lib/validations/rules";
 import type { NoticiaWithLibroCompleto } from "@/lib/types/noticia";
 import type { Paginated } from "@/lib/types/common";
+import type { BuscarNoticiasParams } from "@/services/noticias/noticiaService";
 
-export async function buscarNoticiasAction(
-  searchParams: URLSearchParams
-): Promise<Paginated<NoticiaWithLibroCompleto>> {
+function parseSearchFilters(searchParams: URLSearchParams): BuscarNoticiasParams {
   const page = toSafePositiveInt(Number(searchParams.get("page") ?? 1), 1);
   const pageSize = Math.min(toSafePositiveInt(Number(searchParams.get("pageSize") ?? 20), 20), 100);
 
-  const q = searchParams.get("q")?.trim() ?? undefined;
+  const q = searchParams.get("q")?.trim() || undefined;
 
   const autor = searchParams.get("autor")?.trim() || undefined;
   const categoria = searchParams.get("categoria")?.trim() || undefined;
@@ -21,41 +20,42 @@ export async function buscarNoticiasAction(
 
   const ano_publicacion_str = searchParams.get("ano_publicacion")?.trim();
   const ano_publicacion = ano_publicacion_str ? toSafePositiveInt(Number(ano_publicacion_str), NaN) || undefined : undefined;
-  
+
   const precioMin_str = searchParams.get("precioMin")?.trim();
   const precioMin = precioMin_str ? parseFloat(precioMin_str) : undefined;
-  
+
   const precioMax_str = searchParams.get("precioMax")?.trim();
   const precioMax = precioMax_str ? parseFloat(precioMax_str) : undefined;
 
-  const cleanAutor = autor ? sanitizeText(autor) : undefined;
-  const cleanCategoria = categoria ? sanitizeText(categoria) : undefined;
-  const cleanIdioma = idioma ? sanitizeText(idioma) : undefined;
-  const cleanEditorial = editorial ? sanitizeText(editorial) : undefined;
+  return {
+    page,
+    pageSize,
+    q,
+    autor: autor ? sanitizeText(autor) : undefined,
+    categoria: categoria ? sanitizeText(categoria) : undefined,
+    idioma: idioma ? sanitizeText(idioma) : undefined,
+    editorial: editorial ? sanitizeText(editorial) : undefined,
+    estado: estado as "nuevo" | "usado" | undefined,
+    ano_publicacion,
+    precioMin,
+    precioMax,
+  };
+}
+
+export async function buscarNoticiasAction(
+  searchParams: URLSearchParams
+): Promise<Paginated<NoticiaWithLibroCompleto>> {
+  const filters = parseSearchFilters(searchParams);
 
   try {
-    const result = await buscarNoticias({
-      page,
-      pageSize,
-      q,
-      autor: cleanAutor,
-      categoria: cleanCategoria,
-      idioma: cleanIdioma,
-      editorial: cleanEditorial,
-      ano_publicacion,
-      precioMin,
-      precioMax,
-      estado: estado as "nuevo" | "usado" | undefined,
-    });
-
-    return result;
+    return await buscarNoticias(filters);
   } catch (error) {
     console.error("[buscarAction] Error searching noticias:", error);
     return {
       data: [],
       total: 0,
       page: 1,
-      pageSize,
+      pageSize: filters.pageSize ?? 20,
       totalPages: 0,
     };
   }

--- a/components/SearchResultsClient.tsx
+++ b/components/SearchResultsClient.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import type { NoticiaWithLibroCompleto } from "@/lib/types/noticia";
+import type { Paginated } from "@/lib/types/common";
+import SearchFilters from "@/components/ui/SearchFilters";
+import NewsGrid from "@/components/ui/NewsGrid";
+
+interface SearchResultsClientProps {
+  initialResults: Paginated<NoticiaWithLibroCompleto>;
+}
+
+export default function SearchResultsClient({ initialResults }: SearchResultsClientProps) {
+  const searchParams = useSearchParams();
+
+  const currentFilters = {
+    q: searchParams.get("q") || undefined,
+    autor: searchParams.get("autor") || undefined,
+    categoria: searchParams.get("categoria") || undefined,
+    ano_publicacion: searchParams.get("ano_publicacion") || undefined,
+    idioma: searchParams.get("idioma") || undefined,
+    editorial: searchParams.get("editorial") || undefined,
+    precioMin: searchParams.get("precioMin") || undefined,
+    precioMax: searchParams.get("precioMax") || undefined,
+    estado: searchParams.get("estado") || undefined,
+  };
+
+  return (
+    <div className="flex gap-8 flex-col lg:flex-row">
+      <SearchFilters currentFilters={currentFilters} />
+      <div className="flex-1">
+        <NewsGrid initialNews={initialResults.data} totalPages={initialResults.totalPages} />
+      </div>
+    </div>
+  );
+}

--- a/components/SearchResultsClient.tsx
+++ b/components/SearchResultsClient.tsx
@@ -10,20 +10,40 @@ interface SearchResultsClientProps {
   initialResults: Paginated<NoticiaWithLibroCompleto>;
 }
 
-export default function SearchResultsClient({ initialResults }: SearchResultsClientProps) {
-  const searchParams = useSearchParams();
+interface CurrentFilters {
+  q?: string;
+  autor?: string;
+  categoria?: string;
+  ano_publicacion?: string;
+  idioma?: string;
+  editorial?: string;
+  precioMin?: string;
+  precioMax?: string;
+  estado?: string;
+}
 
-  const currentFilters = {
-    q: searchParams.get("q") || undefined,
-    autor: searchParams.get("autor") || undefined,
-    categoria: searchParams.get("categoria") || undefined,
-    ano_publicacion: searchParams.get("ano_publicacion") || undefined,
-    idioma: searchParams.get("idioma") || undefined,
-    editorial: searchParams.get("editorial") || undefined,
-    precioMin: searchParams.get("precioMin") || undefined,
-    precioMax: searchParams.get("precioMax") || undefined,
-    estado: searchParams.get("estado") || undefined,
-  };
+const FILTER_KEYS = ["q", "autor", "categoria", "ano_publicacion", "idioma", "editorial", "precioMin", "precioMax", "estado"] as const;
+
+function buildCurrentFilters(searchParams: ReturnType<typeof useSearchParams>): CurrentFilters {
+  const filters: CurrentFilters = {};
+
+  for (const key of FILTER_KEYS) {
+    const value = searchParams.get(key);
+    if (value) {
+      filters[key] = value;
+    }
+  }
+
+  return filters;
+}
+
+function useCurrentFilters() {
+  const searchParams = useSearchParams();
+  return buildCurrentFilters(searchParams);
+}
+
+export default function SearchResultsClient({ initialResults }: SearchResultsClientProps) {
+  const currentFilters = useCurrentFilters();
 
   return (
     <div className="flex gap-8 flex-col lg:flex-row">

--- a/components/ui/NewsCardClient.tsx
+++ b/components/ui/NewsCardClient.tsx
@@ -12,19 +12,36 @@ interface NewsCardClientProps {
   isAdminView?: boolean;
 }
 
-export default function NewsCardClient({ noticia, delay = 0, isAdminView = false }: NewsCardClientProps) {
-  const [isVisible, setIsVisible] = useState(noticia.es_visible);
+function getCardStyle(isVisible: boolean, isAdminView: boolean): string {
+  return !isVisible && isAdminView ? "opacity-60 border-dashed" : "";
+}
 
-  const formattedPrice = new Intl.NumberFormat("es-CO", {
+function getVisibilityButtonStyle(isVisible: boolean): string {
+  return isVisible
+    ? "bg-green-50 border-green-200 text-green-600 hover:bg-green-100"
+    : "bg-gray-50 border-gray-200 text-gray-400 hover:bg-gray-100";
+}
+
+function getFormattedPrice(precio: number): string {
+  return new Intl.NumberFormat("es-CO", {
     style: "currency",
     currency: "COP",
     minimumFractionDigits: 0,
-  }).format(noticia.precio);
+  }).format(precio);
+}
 
-  const formattedDate = new Intl.DateTimeFormat("es-CO", {
+function getFormattedDate(fecha: string): string {
+  return new Intl.DateTimeFormat("es-CO", {
     day: "numeric",
     month: "short",
-  }).format(new Date(noticia.fecha_publicacion));
+  }).format(new Date(fecha));
+}
+
+export default function NewsCardClient({ noticia, delay = 0, isAdminView = false }: NewsCardClientProps) {
+  const [isVisible, setIsVisible] = useState(noticia.es_visible);
+
+  const formattedPrice = getFormattedPrice(noticia.precio);
+  const formattedDate = getFormattedDate(noticia.fecha_publicacion);
 
   return (
     <div
@@ -33,7 +50,7 @@ export default function NewsCardClient({ noticia, delay = 0, isAdminView = false
         overflow-hidden shadow-sm hover:shadow-lg hover:shadow-brand-text/8 
         transition-all duration-300 hover:-translate-y-0.5
         animate-in fade-in slide-in-from-bottom-4 fill-mode-both cursor-pointer
-        ${!isVisible && isAdminView ? "opacity-60 border-dashed" : ""}
+        ${getCardStyle(isVisible, isAdminView)}
       `}
       style={{ animationDelay: `${delay}ms` }}
     >
@@ -49,10 +66,7 @@ export default function NewsCardClient({ noticia, delay = 0, isAdminView = false
             }}
             className={`
               w-7 h-7 rounded-full border flex items-center justify-center transition-colors cursor-pointer
-              ${isVisible 
-                ? "bg-green-50 border-green-200 text-green-600 hover:bg-green-100" 
-                : "bg-gray-50 border-gray-200 text-gray-400 hover:bg-gray-100"
-              }
+              ${getVisibilityButtonStyle(isVisible)}
             `}
             title={isVisible ? "Ocultar noticia" : "Mostrar noticia"}
           >

--- a/components/ui/NewsCardClient.tsx
+++ b/components/ui/NewsCardClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, type JSX } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { Eye, EyeOff } from "lucide-react";
@@ -35,6 +35,49 @@ function getFormattedDate(fecha: string): string {
     day: "numeric",
     month: "short",
   }).format(new Date(fecha));
+}
+
+function renderImageContent(noticia: NoticiaWithLibroCompleto): JSX.Element {
+  if (noticia.imagenes && noticia.imagenes.length > 0) {
+    return (
+      <Image
+        src={noticia.imagenes[0]}
+        alt={noticia.libro_titulo || "Libro"}
+        fill
+        className="object-cover transition-transform duration-300 group-hover:scale-105"
+      />
+    );
+  }
+  return (
+    <div className="absolute inset-0 flex items-center justify-center bg-gradient-to-br from-brand-primary/5 to-brand-accent/10">
+      <svg
+        className="w-12 h-12 text-brand-accent/40"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={1}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"
+        />
+      </svg>
+    </div>
+  );
+}
+
+function getAutorDisplay(autorNombre: string | null): JSX.Element | null {
+  if (!autorNombre) return null;
+  return (
+    <p className="text-xs text-brand-secondary/70 truncate">
+      {autorNombre}
+    </p>
+  );
+}
+
+function getCardLabel(isAdminView: boolean): string {
+  return isAdminView ? "Arrastra para reordenar" : "Ver detalles";
 }
 
 export default function NewsCardClient({ noticia, delay = 0, isAdminView = false }: NewsCardClientProps) {
@@ -78,30 +121,7 @@ export default function NewsCardClient({ noticia, delay = 0, isAdminView = false
       <div className="absolute top-0 left-0 right-0 h-0.5 bg-gradient-to-r from-transparent via-brand-primary/40 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
 
       <div className="relative aspect-[3/4] w-full bg-brand-bg overflow-hidden">
-        {noticia.imagenes && noticia.imagenes.length > 0 ? (
-          <Image
-            src={noticia.imagenes[0]}
-            alt={noticia.libro_titulo || "Libro"}
-            fill
-            className="object-cover transition-transform duration-300 group-hover:scale-105"
-          />
-        ) : (
-          <div className="absolute inset-0 flex items-center justify-center bg-gradient-to-br from-brand-primary/5 to-brand-accent/10">
-            <svg
-              className="w-12 h-12 text-brand-accent/40"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={1}
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"
-              />
-            </svg>
-          </div>
-        )}
+        {renderImageContent(noticia)}
       </div>
 
       <div className="p-4 flex flex-col gap-2 flex-1 relative z-10">
@@ -117,15 +137,11 @@ export default function NewsCardClient({ noticia, delay = 0, isAdminView = false
         <h3 className="font-display text-sm font-medium text-brand-text tracking-tight line-clamp-2 group-hover:text-brand-primary transition-colors">
           {noticia.libro_titulo || "Título no disponible"}
         </h3>
-        {noticia.autor_nombre && (
-          <p className="text-xs text-brand-secondary/70 truncate">
-            {noticia.autor_nombre}
-          </p>
-        )}
+        {getAutorDisplay(noticia.autor_nombre)}
 
         <div className="mt-auto pt-2">
           <span className="text-[10px] uppercase tracking-widest text-brand-accent font-medium">
-            {isAdminView ? "Arrastra para reordenar" : "Ver detalles"}
+            {getCardLabel(isAdminView)}
           </span>
         </div>
       </div>

--- a/components/ui/NewsCardClient.tsx
+++ b/components/ui/NewsCardClient.tsx
@@ -4,10 +4,10 @@ import { useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { Eye, EyeOff } from "lucide-react";
-import type { NoticiaWithPrecio } from "@/lib/types/noticia";
+import type { NoticiaWithLibroCompleto } from "@/lib/types/noticia";
 
 interface NewsCardClientProps {
-  noticia: NoticiaWithPrecio;
+  noticia: NoticiaWithLibroCompleto;
   delay?: number;
   isAdminView?: boolean;
 }
@@ -100,9 +100,14 @@ export default function NewsCardClient({ noticia, delay = 0, isAdminView = false
           </span>
         </div>
 
-        <h3 className="font-display text-sm font-medium text-brand-text tracking-tight line-clamp-2 group-hover:text-brand-primary transition-colors min-h-[2.5rem]">
+        <h3 className="font-display text-sm font-medium text-brand-text tracking-tight line-clamp-2 group-hover:text-brand-primary transition-colors">
           {noticia.libro_titulo || "Título no disponible"}
         </h3>
+        {noticia.autor_nombre && (
+          <p className="text-xs text-brand-secondary/70 truncate">
+            {noticia.autor_nombre}
+          </p>
+        )}
 
         <div className="mt-auto pt-2">
           <span className="text-[10px] uppercase tracking-widest text-brand-accent font-medium">

--- a/components/ui/NewsGrid.tsx
+++ b/components/ui/NewsGrid.tsx
@@ -1,20 +1,38 @@
 "use client";
 
-import { useState } from "react";
-import { GripVertical } from "lucide-react";
+import { useState, useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { GripVertical, ChevronLeft, ChevronRight } from "lucide-react";
 import type { NoticiaWithLibroCompleto } from "@/lib/types/noticia";
 import NewsCardClient from "./NewsCardClient";
 
-type NewsItem = NoticiaWithLibroCompleto;
-
 interface NewsGridProps {
-  initialNews: NewsItem[];
+  initialNews?: NoticiaWithLibroCompleto[];
+  totalPages?: number;
   isAdminView?: boolean;
 }
 
-export default function NewsGrid({ initialNews, isAdminView = false }: NewsGridProps) {
+export default function NewsGrid({ initialNews = [], totalPages = 1, isAdminView = false }: NewsGridProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
   const [news, setNews] = useState<NoticiaWithLibroCompleto[]>(initialNews);
   const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
+
+  useEffect(() => {
+    setNews(initialNews);
+  }, [initialNews]);
+
+  const currentPage = Number(searchParams.get("page")) || 1;
+
+  const handlePageChange = (newPage: number) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (newPage === 1) {
+      params.delete("page");
+    } else {
+      params.set("page", String(newPage));
+    }
+    router.push(`?${params.toString()}`);
+  };
 
   const handleDragStart = (index: number) => {
     setDraggedIndex(index);
@@ -54,37 +72,63 @@ export default function NewsGrid({ initialNews, isAdminView = false }: NewsGridP
             />
           </svg>
         </div>
-        <p className="text-brand-secondary text-center">No hay noticias disponibles</p>
+        <p className="text-brand-secondary text-center">No se encontraron libros con esos criterios de búsqueda</p>
       </div>
     );
   }
 
   return (
-    <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
-      {news.map((noticia, index) => (
-        <div
-          key={noticia.id}
-          draggable={isAdminView}
-          onDragStart={() => handleDragStart(index)}
-          onDragOver={(e) => handleDragOver(e, index)}
-          onDragEnd={handleDragEnd}
-          className={`
-            relative
-            ${draggedIndex === index ? "opacity-50 scale-95" : ""}
-            ${isAdminView ? "cursor-grab active:cursor-grabbing" : ""}
-          `}
-        >
-          {isAdminView && (
-            <div className="absolute -left-3 top-1/2 -translate-y-1/2 z-10">
-              <div className="w-6 h-6 rounded bg-brand-bg border border-brand-accent/30 flex items-center justify-center">
-                <GripVertical className="w-3.5 h-3.5 text-brand-secondary" />
+    <>
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
+        {news.map((noticia, index) => (
+          <div
+            key={noticia.id}
+            draggable={isAdminView}
+            onDragStart={() => handleDragStart(index)}
+            onDragOver={(e) => handleDragOver(e, index)}
+            onDragEnd={handleDragEnd}
+            className={`
+              relative
+              ${draggedIndex === index ? "opacity-50 scale-95" : ""}
+              ${isAdminView ? "cursor-grab active:cursor-grabbing" : ""}
+            `}
+          >
+            {isAdminView && (
+              <div className="absolute -left-3 top-1/2 -translate-y-1/2 z-10">
+                <div className="w-6 h-6 rounded bg-brand-bg border border-brand-accent/30 flex items-center justify-center">
+                  <GripVertical className="w-3.5 h-3.5 text-brand-secondary" />
+                </div>
               </div>
-            </div>
-          )}
+            )}
 
-          <NewsCardClient noticia={noticia} delay={index * 75} isAdminView={isAdminView} />
+            <NewsCardClient noticia={noticia} delay={index * 75} isAdminView={isAdminView} />
+          </div>
+        ))}
+      </div>
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center gap-4 mt-8 pt-4 border-t border-brand-accent/10">
+          <button
+            onClick={() => handlePageChange(currentPage - 1)}
+            disabled={currentPage <= 1}
+            className="flex items-center gap-1 px-4 py-2 text-sm font-medium text-brand-secondary hover:text-brand-primary disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          >
+            <ChevronLeft className="w-4 h-4" />
+            Anterior
+          </button>
+          <span className="text-sm text-brand-secondary">
+            Página {currentPage} de {totalPages}
+          </span>
+          <button
+            onClick={() => handlePageChange(currentPage + 1)}
+            disabled={currentPage >= totalPages}
+            className="flex items-center gap-1 px-4 py-2 text-sm font-medium text-brand-secondary hover:text-brand-primary disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          >
+            Siguiente
+            <ChevronRight className="w-4 h-4" />
+          </button>
         </div>
-      ))}
-    </div>
+      )}
+    </>
   );
 }

--- a/components/ui/NewsGrid.tsx
+++ b/components/ui/NewsGrid.tsx
@@ -2,10 +2,10 @@
 
 import { useState } from "react";
 import { GripVertical } from "lucide-react";
-import type { NoticiaWithPrecio } from "@/lib/types/noticia";
+import type { NoticiaWithLibroCompleto } from "@/lib/types/noticia";
 import NewsCardClient from "./NewsCardClient";
 
-type NewsItem = NoticiaWithPrecio;
+type NewsItem = NoticiaWithLibroCompleto;
 
 interface NewsGridProps {
   initialNews: NewsItem[];
@@ -13,7 +13,7 @@ interface NewsGridProps {
 }
 
 export default function NewsGrid({ initialNews, isAdminView = false }: NewsGridProps) {
-  const [news, setNews] = useState<NoticiaWithPrecio[]>(initialNews);
+  const [news, setNews] = useState<NoticiaWithLibroCompleto[]>(initialNews);
   const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
 
   const handleDragStart = (index: number) => {

--- a/components/ui/SearchFilters.tsx
+++ b/components/ui/SearchFilters.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { SlidersHorizontal, X } from "lucide-react";
+
+interface SearchFiltersProps {
+  currentFilters: {
+    q?: string;
+    autor?: string;
+    categoria?: string;
+    ano_publicacion?: string;
+    idioma?: string;
+    editorial?: string;
+    precioMin?: string;
+    precioMax?: string;
+    estado?: string;
+  };
+}
+
+export default function SearchFilters({ currentFilters }: SearchFiltersProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [isOpen, setIsOpen] = useState(false);
+  const [localFilters, setLocalFilters] = useState(currentFilters);
+
+  useEffect(() => {
+    setLocalFilters(currentFilters);
+  }, [searchParams]); // Sincroniza los filtros locales si cambia la URL (e.g. búsqueda en navbar o limpiar)
+
+  const handleFilterChange = (key: string, value: string) => {
+    setLocalFilters((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const applyFilters = () => {
+    const params = new URLSearchParams(searchParams.toString());
+    
+    const filterKeys = ["autor", "categoria", "ano_publicacion", "idioma", "editorial", "precioMin", "precioMax", "estado"];
+    
+    filterKeys.forEach((key) => {
+      const value = localFilters[key as keyof typeof localFilters];
+      if (value && value.trim() !== "") {
+        params.set(key, value);
+      } else {
+        params.delete(key);
+      }
+    });
+
+    router.push(`/?${params.toString()}`);
+    setIsOpen(false);
+  };
+
+  const clearFilters = () => {
+    const params = new URLSearchParams();
+    const q = searchParams.get("q");
+    if (q) params.set("q", q);
+    router.push(`/?${params.toString()}`);
+    setLocalFilters({});
+  };
+
+  return (
+    <>
+      <button
+        onClick={() => setIsOpen(true)}
+        className="lg:hidden fixed bottom-4 right-4 z-50 bg-brand-primary text-white p-3 rounded-full shadow-lg"
+      >
+        <SlidersHorizontal className="w-5 h-5" />
+      </button>
+
+      {isOpen && (
+        <div className="lg:hidden fixed inset-0 z-50 bg-black/50" onClick={() => setIsOpen(false)} />
+      )}
+
+      <div
+        className={`
+          lg:hidden fixed top-0 left-0 right-0 z-50 bg-white border-b border-brand-accent/20
+          transform transition-transform duration-300
+          ${isOpen ? "translate-y-0" : "-translate-y-full"}
+        `}
+      >
+        <div className="p-4 pb-6 max-h-[80vh] overflow-y-auto">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="font-display text-lg font-semibold text-brand-text">Filtros</h2>
+            <button onClick={() => setIsOpen(false)} className="p-2 text-brand-secondary">
+              <X className="w-5 h-5" />
+            </button>
+          </div>
+          <FiltersForm localFilters={localFilters} onFilterChange={handleFilterChange} />
+          <div className="flex gap-2 mt-4">
+            <button
+              onClick={clearFilters}
+              className="flex-1 px-4 py-2 border border-brand-accent/30 text-brand-text rounded-lg hover:bg-brand-accent/10 hover:border-brand-accent cursor-pointer transition-colors"
+            >
+              Limpiar
+            </button>
+            <button
+              onClick={applyFilters}
+              className="flex-1 px-4 py-2 bg-brand-primary text-white rounded-lg hover:bg-brand-primary/90 cursor-pointer transition-colors"
+            >
+              Aplicar
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <aside className="hidden lg:block w-72 flex-shrink-0">
+        <div className="sticky top-24 bg-white border border-brand-accent/20 rounded-xl p-4">
+          <h2 className="font-display text-lg font-semibold text-brand-text mb-4">Filtros</h2>
+          <FiltersForm localFilters={localFilters} onFilterChange={handleFilterChange} />
+          <div className="flex gap-2 mt-4">
+            <button
+              onClick={clearFilters}
+              className="flex-1 px-4 py-2 border border-brand-accent/30 text-brand-text rounded-lg text-sm hover:bg-brand-accent/10 hover:border-brand-accent cursor-pointer transition-colors"
+            >
+              Limpiar
+            </button>
+            <button
+              onClick={applyFilters}
+              className="flex-1 px-4 py-2 bg-brand-primary text-white rounded-lg text-sm hover:bg-brand-primary/90 cursor-pointer transition-colors"
+            >
+              Aplicar
+            </button>
+          </div>
+        </div>
+      </aside>
+    </>
+  );
+}
+
+function FiltersForm({
+  localFilters,
+  onFilterChange,
+}: {
+  localFilters: SearchFiltersProps["currentFilters"];
+  onFilterChange: (key: string, value: string) => void;
+}) {
+  return (
+    <div className="space-y-4">
+      <div>
+        <label className="block text-xs font-medium text-brand-secondary mb-1">Autor</label>
+        <input
+          type="text"
+          value={localFilters.autor || ""}
+          onChange={(e) => onFilterChange("autor", e.target.value)}
+          placeholder="Nombre del autor"
+          className="w-full px-3 py-2 border border-brand-accent/20 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-primary/30"
+        />
+      </div>
+
+      <div>
+        <label className="block text-xs font-medium text-brand-secondary mb-1">Editorial</label>
+        <input
+          type="text"
+          value={localFilters.editorial || ""}
+          onChange={(e) => onFilterChange("editorial", e.target.value)}
+          placeholder="Nombre de la editorial"
+          className="w-full px-3 py-2 border border-brand-accent/20 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-primary/30"
+        />
+      </div>
+
+      <div>
+        <label className="block text-xs font-medium text-brand-secondary mb-1">Idioma</label>
+        <select
+          value={localFilters.idioma || ""}
+          onChange={(e) => onFilterChange("idioma", e.target.value)}
+          className="w-full px-3 py-2 border border-brand-accent/20 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-primary/30"
+        >
+          <option value="">Todos</option>
+          <option value="Español">Español</option>
+          <option value="Inglés">Inglés</option>
+          <option value="Francés">Francés</option>
+          <option value="Alemán">Alemán</option>
+          <option value="Portugués">Portugués</option>
+        </select>
+      </div>
+
+      <div>
+        <label className="block text-xs font-medium text-brand-secondary mb-1">Categoría</label>
+        <input
+          type="text"
+          value={localFilters.categoria || ""}
+          onChange={(e) => onFilterChange("categoria", e.target.value)}
+          placeholder="Género o categoría"
+          className="w-full px-3 py-2 border border-brand-accent/20 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-primary/30"
+        />
+      </div>
+
+      <div>
+        <label className="block text-xs font-medium text-brand-secondary mb-1">Año de publicación</label>
+        <input
+          type="number"
+          value={localFilters.ano_publicacion || ""}
+          onChange={(e) => onFilterChange("ano_publicacion", e.target.value)}
+          placeholder="Ej: 2023"
+          min="1900"
+          max={new Date().getFullYear()}
+          className="w-full px-3 py-2 border border-brand-accent/20 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-primary/30"
+        />
+      </div>
+
+      <div>
+        <label className="block text-xs font-medium text-brand-secondary mb-1">Precio (COP)</label>
+        <div className="flex gap-2">
+          <input
+            type="number"
+            value={localFilters.precioMin || ""}
+            onChange={(e) => onFilterChange("precioMin", e.target.value)}
+            placeholder="Mín"
+            min="0"
+            className="w-1/2 px-3 py-2 border border-brand-accent/20 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-primary/30"
+          />
+          <input
+            type="number"
+            value={localFilters.precioMax || ""}
+            onChange={(e) => onFilterChange("precioMax", e.target.value)}
+            placeholder="Máx"
+            min="0"
+            className="w-1/2 px-3 py-2 border border-brand-accent/20 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-primary/30"
+          />
+        </div>
+      </div>
+
+      <div>
+        <label className="block text-xs font-medium text-brand-secondary mb-1">Estado</label>
+        <select
+          value={localFilters.estado || ""}
+          onChange={(e) => onFilterChange("estado", e.target.value)}
+          className="w-full px-3 py-2 border border-brand-accent/20 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-primary/30"
+        >
+          <option value="">Todos</option>
+          <option value="nuevo">Nuevo</option>
+          <option value="usado">Usado</option>
+        </select>
+      </div>
+    </div>
+  );
+}

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -34,6 +34,28 @@ export const createClient = async () => {
 };
 
 /**
+ * Cliente público para operaciones que no requieren autenticación.
+ * Usa la anon key y NO maneja cookies (no necesita sesión de usuario).
+ * Para búsquedas públicas, lectura de productos, etc.
+ */
+export const createPublicClient = () => {
+  return createServerClient<Database>(
+    supabaseUrl!,
+    supabaseKey!,
+    {
+      cookies: {
+        getAll() {
+          return [];
+        },
+        setAll() {
+          // no-op: no se necesitan cookies para cliente público
+        },
+      },
+    },
+  );
+};
+
+/**
  * Cliente admin que usa la service_role key para operaciones privilegiadas
  * del lado del servidor (ej: inserciones durante el registro).
  * Bypasea RLS — usar SOLO en Server Actions seguros, nunca exponer al cliente.

--- a/lib/types/noticia.ts
+++ b/lib/types/noticia.ts
@@ -53,3 +53,17 @@ export type NoticiasListResponse = PaginatedResponse<NoticiaWithLibro>;
 
 /** Respuesta de mutación de noticia (crear/editar/eliminar). */
 export type NoticiaActionResponse = ActionResponse;
+
+// ─── Filtros ────────────────────────────────────────────────────────
+
+export interface NoticiaFilters {
+  searchTerm?: string;
+  autor?: string;
+  categoria?: string;
+  ano_publicacion?: number;
+  idioma?: string;
+  editorial?: string;
+  precioMin?: number;
+  precioMax?: number;
+  estado?: "nuevo" | "usado";
+}

--- a/lib/types/noticia.ts
+++ b/lib/types/noticia.ts
@@ -38,11 +38,12 @@ export interface NoticiaWithLibro extends NoticiaRow {
   libro_titulo: string | null;
 }
 
-/** Noticia con título y precio del libro asociado (para homepage). */
-export interface NoticiaWithPrecio extends NoticiaRow {
+/** Noticia con datos completos del libro asociado (título, precio, autor) para homepage. */
+export interface NoticiaWithLibroCompleto extends NoticiaRow {
   libro_titulo: string | null;
   precio: number;
   imagenes: string[] | null;
+  autor_nombre: string | null;
 }
 
 // ─── Respuestas de Server Actions ──────────────────────────────────

--- a/lib/types/supabase.ts
+++ b/lib/types/supabase.ts
@@ -517,11 +517,25 @@ export type Database = {
             referencedColumns: ["id"]
           },
           {
+            foreignKeyName: "Libro_id_autor_fkey"
+            columns: ["id_autor"]
+            isOneToOne: false
+            referencedRelation: "vista_noticias_completa"
+            referencedColumns: ["autor_id"]
+          },
+          {
             foreignKeyName: "Libro_id_categoria_fkey"
             columns: ["id_categoria"]
             isOneToOne: false
             referencedRelation: "categoria"
             referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "Libro_id_categoria_fkey"
+            columns: ["id_categoria"]
+            isOneToOne: false
+            referencedRelation: "vista_noticias_completa"
+            referencedColumns: ["categoria_id"]
           },
           {
             foreignKeyName: "Libro_id_modeloRA_fkey"
@@ -626,6 +640,13 @@ export type Database = {
             referencedColumns: ["id"]
           },
           {
+            foreignKeyName: "PreferenciaAutor_id_autor_fkey"
+            columns: ["id_autor"]
+            isOneToOne: false
+            referencedRelation: "vista_noticias_completa"
+            referencedColumns: ["autor_id"]
+          },
+          {
             foreignKeyName: "PreferenciaAutor_id_usuario_fkey"
             columns: ["id_usuario"]
             isOneToOne: false
@@ -660,6 +681,13 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "categoria"
             referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "PreferenciaCategoria_id_categoria_fkey"
+            columns: ["id_categoria"]
+            isOneToOne: false
+            referencedRelation: "vista_noticias_completa"
+            referencedColumns: ["categoria_id"]
           },
           {
             foreignKeyName: "PreferenciaCategoria_id_usuario_fkey"
@@ -972,6 +1000,46 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "tienda"
             referencedColumns: ["id"]
+          },
+        ]
+      }
+      vista_noticias_completa: {
+        Row: {
+          ano_publicacion: number | null
+          autor_id: number | null
+          autor_nombre: string | null
+          categoria_id: number | null
+          categoria_nombre: string | null
+          deleted_at: string | null
+          editorial: string | null
+          es_visible: boolean | null
+          estado: Database["public"]["Enums"]["condicion_libro"] | null
+          fecha_expiracion: string | null
+          fecha_publicacion: string | null
+          id: string | null
+          id_libro: string | null
+          idioma: string | null
+          imagenes: Json | null
+          isbn: string | null
+          libro_fecha_publicacion: string | null
+          paginas: number | null
+          precio: number | null
+          titulo: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "Noticias_id_libro_fkey"
+            columns: ["id_libro"]
+            isOneToOne: false
+            referencedRelation: "libro"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "Noticias_id_libro_fkey"
+            columns: ["id_libro"]
+            isOneToOne: false
+            referencedRelation: "vista_inventario"
+            referencedColumns: ["libro_id"]
           },
         ]
       }

--- a/models/noticiaModel.ts
+++ b/models/noticiaModel.ts
@@ -1,4 +1,4 @@
-import { createAdminClient } from "@/lib/supabase/server";
+import { createAdminClient, createPublicClient } from "@/lib/supabase/server";
 import type { Paginated } from "@/lib/types/common";
 import type {
   NoticiaId,
@@ -9,9 +9,10 @@ import type {
   InsertNoticiaPayload,
   UpdateNoticiaPayload,
   NoticiaRow,
+  NoticiaFilters,
 } from "@/lib/types/noticia";
 import { buildSafePagination, normalizePagination } from "@/lib/pagination";
-import { formatILIKE } from "@/lib/validations/db-utils";
+import { formatILIKE, quotePostgrestFilterValue } from "@/lib/validations/db-utils";
 
 interface NoticiaBaseRow {
   id: string;
@@ -136,9 +137,9 @@ export async function softDeleteNoticiaByLibroId(id_libro: LibroId): Promise<voi
 export async function getNoticiaById(
   id: NoticiaId
 ): Promise<NoticiaRow | null> {
-  const adminClient = createAdminClient();
+  const publicClient = createPublicClient();
 
-  const { data, error } = await adminClient
+  const { data, error } = await publicClient
     .from("noticias")
     .select("*")
     .eq("id", id)
@@ -156,9 +157,9 @@ export async function getNoticiaById(
 export async function getNoticiaByLibroId(
   libroId: LibroId
 ): Promise<NoticiaRow | null> {
-  const adminClient = createAdminClient();
+  const publicClient = createPublicClient();
 
-  const { data, error } = await adminClient
+  const { data, error } = await publicClient
     .from("noticias")
     .select("*")
     .eq("id_libro", libroId)
@@ -178,11 +179,11 @@ export async function getNoticias(
   pageSize: number = 10,
   searchTerm?: SearchTerm
 ): Promise<Paginated<NoticiaWithLibro>> {
-  const adminClient = createAdminClient();
+  const publicClient = createPublicClient();
 
   const { safePage, safePageSize, from, to } = buildSafePagination(page, pageSize);
 
-  let query = adminClient
+  let query = publicClient
     .from("noticias")
     .select("*, libro!inner(titulo)", { count: "exact" })
     .is("deleted_at", null)
@@ -209,11 +210,11 @@ export async function getNoticiasWithLibroCompleto(
   page: number = 1,
   pageSize: number = 20
 ): Promise<Paginated<NoticiaWithLibroCompleto>> {
-  const adminClient = createAdminClient();
+  const publicClient = createPublicClient();
 
   const { safePage, safePageSize, from, to } = buildSafePagination(page, pageSize);
 
-  const { data, error, count } = await adminClient
+  const { data, error, count } = await publicClient
     .from("noticias")
     .select("*, libro!inner(titulo, precio, autor(nombre)), imagenes", { count: "exact" })
     .is("deleted_at", null)
@@ -227,6 +228,108 @@ export async function getNoticiasWithLibroCompleto(
   }
 
   const normalized: NoticiaWithLibroCompleto[] = (data as unknown as NoticiaConLibroCompleto[] | null)?.map(mapNoticiaConLibroCompleto) ?? [];
+
+  return normalizePagination(normalized, count ?? 0, safePage, safePageSize);
+}
+
+interface VistaNoticiaCompleta {
+  id: string;
+  id_libro: string;
+  fecha_publicacion: string;
+  fecha_expiracion: string;
+  es_visible: boolean;
+  deleted_at: string | null;
+  imagenes: string[] | null;
+  titulo: string | null;
+  isbn: string | null;
+  precio: number | null;
+  idioma: string | null;
+  editorial: string | null;
+  estado: string | null;
+  ano_publicacion: number | null;
+  autor_id: number | null;
+  autor_nombre: string | null;
+  categoria_id: number | null;
+  categoria_nombre: string | null;
+}
+
+function mapVistaToNoticiaWithLibroCompleto(row: VistaNoticiaCompleta): NoticiaWithLibroCompleto {
+  return {
+    id: row.id,
+    id_libro: row.id_libro,
+    fecha_publicacion: row.fecha_publicacion,
+    fecha_expiracion: row.fecha_expiracion,
+    es_visible: row.es_visible,
+    deleted_at: row.deleted_at,
+    imagenes: row.imagenes,
+    libro_titulo: row.titulo,
+    precio: row.precio ?? 0,
+    autor_nombre: row.autor_nombre,
+  };
+}
+
+export async function getAllNoticiasWithLibroCompleto(
+  page: number = 1,
+  pageSize: number = 20,
+  filters?: NoticiaFilters
+): Promise<Paginated<NoticiaWithLibroCompleto>> {
+  const publicClient = createPublicClient();
+
+  const { safePage, safePageSize, from, to } = buildSafePagination(page, pageSize);
+
+  let query = publicClient
+    .from("vista_noticias_completa")
+    .select("*", { count: "exact" })
+    .range(from, to)
+    .order("fecha_publicacion", { ascending: false });
+
+  if (filters?.searchTerm && filters.searchTerm.trim() !== "") {
+    const pattern = quotePostgrestFilterValue(formatILIKE(filters.searchTerm));
+    query = query.or(
+      `titulo.ilike.${pattern},isbn.ilike.${pattern},autor_nombre.ilike.${pattern}`
+    );
+  }
+
+  if (filters?.autor && filters.autor.trim() !== "") {
+    query = query.ilike("autor_nombre", formatILIKE(filters.autor));
+  }
+
+  if (filters?.categoria && filters.categoria.trim() !== "") {
+    query = query.ilike("categoria_nombre", formatILIKE(filters.categoria));
+  }
+
+  if (filters?.ano_publicacion) {
+    query = query.eq("ano_publicacion", filters.ano_publicacion);
+  }
+
+  if (filters?.idioma && filters.idioma.trim() !== "") {
+    query = query.eq("idioma", filters.idioma);
+  }
+
+  if (filters?.editorial && filters.editorial.trim() !== "") {
+    query = query.eq("editorial", filters.editorial);
+  }
+
+  if (filters?.estado) {
+    query = query.eq("estado", filters.estado);
+  }
+
+  if (filters?.precioMin !== undefined) {
+    query = query.gte("precio", filters.precioMin);
+  }
+
+  if (filters?.precioMax !== undefined) {
+    query = query.lte("precio", filters.precioMax);
+  }
+
+  const { data, error, count } = await query;
+
+  if (error) {
+    console.error("[noticiaModel] Error listando noticias con filtros:", error);
+    throw error;
+  }
+
+  const normalized: NoticiaWithLibroCompleto[] = (data as VistaNoticiaCompleta[] | null)?.map(mapVistaToNoticiaWithLibroCompleto) ?? [];
 
   return normalizePagination(normalized, count ?? 0, safePage, safePageSize);
 }

--- a/models/noticiaModel.ts
+++ b/models/noticiaModel.ts
@@ -268,6 +268,45 @@ function mapVistaToNoticiaWithLibroCompleto(row: VistaNoticiaCompleta): NoticiaW
   };
 }
 
+function applyNoticiaFilters(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  query: any,
+  filters: NoticiaFilters
+): typeof query {
+  const { searchTerm, autor, categoria, ano_publicacion, idioma, editorial, estado, precioMin, precioMax } = filters;
+
+  if (searchTerm?.trim()) {
+    const pattern = quotePostgrestFilterValue(formatILIKE(searchTerm));
+    query = query.or(`titulo.ilike.${pattern},isbn.ilike.${pattern},autor_nombre.ilike.${pattern}`);
+  }
+  if (autor?.trim()) {
+    query = query.ilike("autor_nombre", formatILIKE(autor));
+  }
+  if (categoria?.trim()) {
+    query = query.ilike("categoria_nombre", formatILIKE(categoria));
+  }
+  if (ano_publicacion !== undefined) {
+    query = query.eq("ano_publicacion", ano_publicacion);
+  }
+  if (idioma?.trim()) {
+    query = query.eq("idioma", idioma);
+  }
+  if (editorial?.trim()) {
+    query = query.eq("editorial", editorial);
+  }
+  if (estado) {
+    query = query.eq("estado", estado);
+  }
+  if (precioMin !== undefined) {
+    query = query.gte("precio", precioMin);
+  }
+  if (precioMax !== undefined) {
+    query = query.lte("precio", precioMax);
+  }
+
+  return query;
+}
+
 export async function getAllNoticiasWithLibroCompleto(
   page: number = 1,
   pageSize: number = 20,
@@ -283,43 +322,8 @@ export async function getAllNoticiasWithLibroCompleto(
     .range(from, to)
     .order("fecha_publicacion", { ascending: false });
 
-  if (filters?.searchTerm && filters.searchTerm.trim() !== "") {
-    const pattern = quotePostgrestFilterValue(formatILIKE(filters.searchTerm));
-    query = query.or(
-      `titulo.ilike.${pattern},isbn.ilike.${pattern},autor_nombre.ilike.${pattern}`
-    );
-  }
-
-  if (filters?.autor && filters.autor.trim() !== "") {
-    query = query.ilike("autor_nombre", formatILIKE(filters.autor));
-  }
-
-  if (filters?.categoria && filters.categoria.trim() !== "") {
-    query = query.ilike("categoria_nombre", formatILIKE(filters.categoria));
-  }
-
-  if (filters?.ano_publicacion) {
-    query = query.eq("ano_publicacion", filters.ano_publicacion);
-  }
-
-  if (filters?.idioma && filters.idioma.trim() !== "") {
-    query = query.eq("idioma", filters.idioma);
-  }
-
-  if (filters?.editorial && filters.editorial.trim() !== "") {
-    query = query.eq("editorial", filters.editorial);
-  }
-
-  if (filters?.estado) {
-    query = query.eq("estado", filters.estado);
-  }
-
-  if (filters?.precioMin !== undefined) {
-    query = query.gte("precio", filters.precioMin);
-  }
-
-  if (filters?.precioMax !== undefined) {
-    query = query.lte("precio", filters.precioMax);
+  if (filters) {
+    query = applyNoticiaFilters(query, filters);
   }
 
   const { data, error, count } = await query;

--- a/models/noticiaModel.ts
+++ b/models/noticiaModel.ts
@@ -5,7 +5,7 @@ import type {
   LibroId,
   SearchTerm,
   NoticiaWithLibro,
-  NoticiaWithPrecio,
+  NoticiaWithLibroCompleto,
   InsertNoticiaPayload,
   UpdateNoticiaPayload,
   NoticiaRow,
@@ -27,9 +27,9 @@ interface NoticiaConLibroTitulo extends NoticiaBaseRow {
   libro: { titulo: string | null } | null;
 }
 
-interface NoticiaConLibroPrecio extends NoticiaBaseRow {
+interface NoticiaConLibroCompleto extends NoticiaBaseRow {
   imagenes: string[] | null;
-  libro: { titulo: string | null; precio: number | null } | null;
+  libro: { titulo: string | null; precio: number | null; autor: { nombre: string | null } | null } | null;
 }
 
 function mapNoticiaBase(row: NoticiaBaseRow) {
@@ -51,12 +51,13 @@ function mapNoticiaConLibro(row: NoticiaConLibroTitulo): NoticiaWithLibro {
   };
 }
 
-function mapNoticiaConPrecio(row: NoticiaConLibroPrecio): NoticiaWithPrecio {
+function mapNoticiaConLibroCompleto(row: NoticiaConLibroCompleto): NoticiaWithLibroCompleto {
   return {
     ...mapNoticiaBase(row),
     libro_titulo: row.libro?.titulo ?? null,
     precio: row.libro?.precio ?? 0,
     imagenes: row.imagenes ?? null,
+    autor_nombre: row.libro?.autor?.nombre ?? null,
   };
 }
 
@@ -204,17 +205,17 @@ export async function getNoticias(
   return normalizePagination(normalized, count ?? 0, safePage, safePageSize);
 }
 
-export async function getNoticiasWithPrecio(
+export async function getNoticiasWithLibroCompleto(
   page: number = 1,
   pageSize: number = 20
-): Promise<Paginated<NoticiaWithPrecio>> {
+): Promise<Paginated<NoticiaWithLibroCompleto>> {
   const adminClient = createAdminClient();
 
   const { safePage, safePageSize, from, to } = buildSafePagination(page, pageSize);
 
   const { data, error, count } = await adminClient
     .from("noticias")
-    .select("*, libro!inner(titulo, precio), imagenes", { count: "exact" })
+    .select("*, libro!inner(titulo, precio, autor(nombre)), imagenes", { count: "exact" })
     .is("deleted_at", null)
     .eq("es_visible", true)
     .range(from, to)
@@ -225,7 +226,7 @@ export async function getNoticiasWithPrecio(
     throw error;
   }
 
-  const normalized: NoticiaWithPrecio[] = (data as unknown as NoticiaConLibroPrecio[] | null)?.map(mapNoticiaConPrecio) ?? [];
+  const normalized: NoticiaWithLibroCompleto[] = (data as unknown as NoticiaConLibroCompleto[] | null)?.map(mapNoticiaConLibroCompleto) ?? [];
 
   return normalizePagination(normalized, count ?? 0, safePage, safePageSize);
 }

--- a/services/noticias/noticiaService.ts
+++ b/services/noticias/noticiaService.ts
@@ -1,0 +1,62 @@
+import { getAllNoticiasWithLibroCompleto } from "@/models/noticiaModel";
+import type { NoticiaFilters } from "@/lib/types/noticia";
+import type { Paginated } from "@/lib/types/common";
+import type { NoticiaWithLibroCompleto } from "@/lib/types/noticia";
+
+export interface BuscarNoticiasParams {
+  page?: number;
+  pageSize?: number;
+  q?: string;
+  autor?: string;
+  categoria?: string;
+  ano_publicacion?: number;
+  idioma?: string;
+  editorial?: string;
+  precioMin?: number;
+  precioMax?: number;
+  estado?: "nuevo" | "usado";
+}
+
+export async function buscarNoticias(
+  params: BuscarNoticiasParams
+): Promise<Paginated<NoticiaWithLibroCompleto>> {
+  const {
+    page = 1,
+    pageSize = 20,
+    q,
+    autor,
+    categoria,
+    ano_publicacion,
+    idioma,
+    editorial,
+    precioMin,
+    precioMax,
+    estado,
+  } = params;
+
+  const filters: NoticiaFilters = {
+    searchTerm: q,
+    autor,
+    categoria,
+    ano_publicacion,
+    idioma,
+    editorial,
+    precioMin,
+    precioMax,
+    estado,
+  };
+
+  try {
+    const result = await getAllNoticiasWithLibroCompleto(page, pageSize, filters);
+    return result;
+  } catch (error) {
+    console.error("[noticiaService] Error searching noticias:", error);
+    return {
+      data: [],
+      total: 0,
+      page: 1,
+      pageSize,
+      totalPages: 0,
+    };
+  }
+}

--- a/supabase/migrations/20260518_crear_vista_noticias_completa.sql
+++ b/supabase/migrations/20260518_crear_vista_noticias_completa.sql
@@ -1,0 +1,34 @@
+-- Migration: Create vista_noticias_completa for public search with OR semantics
+-- Fecha: 2026-05-18
+-- Objetivo: Vista que aplana las columnas de libros, autores y categorías
+-- para permitir búsquedas OR con .or() en PostgREST
+
+CREATE OR REPLACE VIEW public.vista_noticias_completa AS
+SELECT 
+  n.id,
+  n.id_libro,
+  n.fecha_publicacion,
+  n.fecha_expiracion,
+  n.es_visible,
+  n.deleted_at,
+  n.imagenes,
+  l.titulo,
+  l.isbn,
+  l.precio,
+  l.paginas,
+  l.idioma,
+  l.editorial,
+  l.estado,
+  l.fecha_publicacion AS libro_fecha_publicacion,
+  l.ano_publicacion,
+  a.id AS autor_id,
+  a.nombre AS autor_nombre,
+  c.id AS categoria_id,
+  c.nombre AS categoria_nombre
+FROM public.noticias n
+INNER JOIN public.libro l ON l.id = n.id_libro
+INNER JOIN public.autor a ON a.id = l.id_autor
+INNER JOIN public.categoria c ON c.id = l.id_categoria
+WHERE n.deleted_at IS NULL;
+
+COMMENT ON VIEW public.vista_noticias_completa IS 'Vista para búsqueda pública de noticias con datos aplanados de libro, autor y categoría';

--- a/supabase/migrations/20260519_agregar_politicas_rls_noticias_publicas.sql
+++ b/supabase/migrations/20260519_agregar_politicas_rls_noticias_publicas.sql
@@ -30,38 +30,34 @@ CREATE POLICY "Permitir lectura pública noticias"
 ON public.noticias
 FOR SELECT
 TO anon
-USING (true)
-WITH CHECK (true);
+USING (true);
 
 -- Política para libro: cualquier usuario puede LEER todos los libros
 CREATE POLICY "Permitir lectura pública libros"
 ON public.libro
 FOR SELECT
 TO anon
-USING (true)
-WITH CHECK (true);
+USING (true);
 
 -- Política para autor: cualquier usuario puede LEER todos los autores
 CREATE POLICY "Permitir lectura pública autores"
 ON public.autor
 FOR SELECT
 TO anon
-USING (true)
-WITH CHECK (true);
+USING (true);
 
 -- Política para categoría: cualquier usuario puede LEER todas las categorías
 CREATE POLICY "Permitir lectura pública categorías"
 ON public.categoria
 FOR SELECT
 TO anon
-USING (true)
-WITH CHECK (true);
+USING (true);
 
 -- ============================================================
 -- 4. NOTA IMPORTANTE
 -- ============================================================
 --
--- Las políticas INSERT, UPDATE, DELETE siguen controlladas por RLS.
+-- Las políticas INSERT, UPDATE, DELETE siguen controladas por RLS.
 -- Solo el service_role key (createAdminClient) puede modificar datos.
 --
 -- La tabla noticias tiene un campo 'deleted_at' para soft-delete.

--- a/supabase/migrations/20260519_agregar_politicas_rls_noticias_publicas.sql
+++ b/supabase/migrations/20260519_agregar_politicas_rls_noticias_publicas.sql
@@ -1,0 +1,70 @@
+-- Migración: Agregar políticas RLS para lectura pública de noticias
+-- Fecha: 2026-05-19
+-- Objetivo: Permitir que el cliente público (anon key) pueda leer noticias,
+-- libros, autores y categorías sin filtro es_visible para la búsqueda pública
+
+-- ============================================================
+-- 1. HABILITAR RLS EN TABLAS (si no está habilitado)
+-- ============================================================
+
+ALTER TABLE public.noticias ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.libro ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.autor ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.categoria ENABLE ROW LEVEL SECURITY;
+
+-- ============================================================
+-- 2. ELIMINAR POLÍTICAS EXISTENTES ( idempotente )
+-- ============================================================
+
+DROP POLICY IF EXISTS "Permitir lectura pública noticias" ON public.noticias;
+DROP POLICY IF EXISTS "Permitir lectura pública libros" ON public.libro;
+DROP POLICY IF EXISTS "Permitir lectura pública autores" ON public.autor;
+DROP POLICY IF EXISTS "Permitir lectura pública categorías" ON public.categoria;
+
+-- ============================================================
+-- 3. CREAR POLÍTICAS DE LECTURA PÚBLICA
+-- ============================================================
+
+-- Política para noticias: cualquier usuario puede LEER todos los registros
+CREATE POLICY "Permitir lectura pública noticias"
+ON public.noticias
+FOR SELECT
+TO anon
+USING (true)
+WITH CHECK (true);
+
+-- Política para libro: cualquier usuario puede LEER todos los libros
+CREATE POLICY "Permitir lectura pública libros"
+ON public.libro
+FOR SELECT
+TO anon
+USING (true)
+WITH CHECK (true);
+
+-- Política para autor: cualquier usuario puede LEER todos los autores
+CREATE POLICY "Permitir lectura pública autores"
+ON public.autor
+FOR SELECT
+TO anon
+USING (true)
+WITH CHECK (true);
+
+-- Política para categoría: cualquier usuario puede LEER todas las categorías
+CREATE POLICY "Permitir lectura pública categorías"
+ON public.categoria
+FOR SELECT
+TO anon
+USING (true)
+WITH CHECK (true);
+
+-- ============================================================
+-- 4. NOTA IMPORTANTE
+-- ============================================================
+--
+-- Las políticas INSERT, UPDATE, DELETE siguen controlladas por RLS.
+-- Solo el service_role key (createAdminClient) puede modificar datos.
+--
+-- La tabla noticias tiene un campo 'deleted_at' para soft-delete.
+-- La query pública debe filtrar WHERE deleted_at IS NULL.
+-- Esto ya está implementado en el modelo noticiaModel.ts existente.
+--


### PR DESCRIPTION
- Crear políticas RLS para lectura pública de noticias, libro, autor y categoría
- Agregar createPublicClient() en server.ts para operaciones sin cookies
- Refactorizar noticiaModel: funciones de lectura usan createPublicClient
- Crear vista vista_noticias_completa para búsqueda OR con columnas aplanadas
- Crear componente SearchFilters con sidebar desktop y panel móvil colapsable
- Crear SearchResultsClient con re-fetch automático al cambiar URL
- Actualizar NewsGrid para soportar paginación y datos externos
- Modificar home page para integrar búsqueda y filtros
- Crear server action buscarNoticiasAction
- Agregar interfaz NoticiaFilters para tipos de búsqueda