### PR TITLE
feat(historial-compras): add purchase detail page with payment and de…

### DIFF
--- a/app/(with-navbar)/historial-compras/[id]/page.tsx
+++ b/app/(with-navbar)/historial-compras/[id]/page.tsx
@@ -1,0 +1,43 @@
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+import { fetchCompraDetalleAction } from "../actions";
+import CompraDetalleClient from "@/components/compra/CompraDetalleClient";
+
+interface CompraDetallePageProps {
+  params: Promise<{ id: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: CompraDetallePageProps): Promise<Metadata> {
+  const { id } = await params;
+  const compra = await fetchCompraDetalleAction(id);
+
+  return {
+    title: compra
+      ? `Compra ${compra.id.slice(0, 8)} — Biblioteca de Alejandría`
+      : "Compra no encontrada",
+    description: compra
+      ? `Detalle de compra realizada el ${new Date(compra.fecha).toLocaleDateString("es-VE")}`
+      : "Detalle de compra",
+  };
+}
+
+export default async function CompraDetallePage({
+  params,
+}: CompraDetallePageProps) {
+  const { id } = await params;
+  const compra = await fetchCompraDetalleAction(id);
+
+  if (!compra) {
+    notFound();
+  }
+
+  return (
+    <div className="flex-1 bg-brand-bg flex flex-col">
+      <main className="flex-1 w-full max-w-4xl mx-auto px-4 md:px-8 py-8 md:py-12">
+        <CompraDetalleClient initialData={compra} />
+      </main>
+    </div>
+  );
+}

--- a/app/(with-navbar)/historial-compras/actions.ts
+++ b/app/(with-navbar)/historial-compras/actions.ts
@@ -1,7 +1,16 @@
 "use server";
 
-import { obtenerHistorialCompras } from "@/services/compra/compraService";
-import type { CompraListParams, CompraHistorialResponse } from "@/lib/types/compra";
+import {
+  obtenerHistorialCompras,
+  obtenerDetalleCompra,
+  obtenerDetalleExtra,
+} from "@/services/compra/compraService";
+import type {
+  CompraListParams,
+  CompraHistorialResponse,
+  CompraConItems,
+  CompraDetalleExtra,
+} from "@/lib/types/compra";
 
 export async function fetchHistorialComprasAction(
   params: CompraListParams
@@ -17,5 +26,27 @@ export async function fetchHistorialComprasAction(
       pageSize: params.pageSize,
       totalPages: 0,
     };
+  }
+}
+
+export async function fetchCompraDetalleAction(
+  idCompra: string
+): Promise<CompraConItems | null> {
+  try {
+    return await obtenerDetalleCompra(idCompra);
+  } catch (error) {
+    console.error("[historialComprasAction] Error fetching compra detail:", error);
+    return null;
+  }
+}
+
+export async function fetchCompraDetalleExtraAction(
+  idCompra: string
+): Promise<CompraDetalleExtra | null> {
+  try {
+    return await obtenerDetalleExtra(idCompra);
+  } catch (error) {
+    console.error("[historialComprasAction] Error fetching compra extra:", error);
+    return null;
   }
 }

--- a/components/compra/CompraCard.tsx
+++ b/components/compra/CompraCard.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import type { CompraConItems } from "@/lib/types/compra";
 import CompraCardHeader from "./CompraCardHeader";
 import CompraItemCard from "./CompraItemCard";
@@ -20,13 +21,12 @@ export default function CompraCard({ compra }: CompraCardProps) {
         ))}
       </div>
       <div className="px-5 py-3 border-t border-brand-accent/10">
-        <button
-          disabled
-          className="px-4 py-2 text-xs font-medium rounded-lg border border-brand-accent/20 bg-white text-brand-secondary/40 cursor-not-allowed"
-          title="Próximamente"
+        <Link
+          href={`/historial-compras/${compra.id}`}
+          className="inline-block px-4 py-2 text-xs font-medium rounded-lg border border-brand-accent/20 bg-white text-brand-secondary hover:text-brand-primary hover:border-brand-primary/30 transition-colors"
         >
           Ver detalle de compra
-        </button>
+        </Link>
       </div>
     </article>
   );

--- a/components/compra/CompraDetalleClient.tsx
+++ b/components/compra/CompraDetalleClient.tsx
@@ -1,0 +1,367 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import { ArrowLeft, CreditCard, Truck, CheckCircle2, Clock, Package, ChevronDown, RotateCcw } from "lucide-react";
+import CompraItemCard from "./CompraItemCard";
+import { fetchCompraDetalleExtraAction } from "@/app/(with-navbar)/historial-compras/actions";
+import { formatPrecio } from "@/lib/utils/format";
+import type { CompraConItems, CompraDetalleExtra } from "@/lib/types/compra";
+
+interface CompraDetalleClientProps {
+  initialData: CompraConItems;
+}
+
+function formatFecha(fecha: string): string {
+  return new Intl.DateTimeFormat("es-CO", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  }).format(new Date(fecha));
+}
+
+const DELIVERY_STEPS = ["en preparacion", "enviado", "entregado"] as const;
+
+const STEP_LABELS: Record<string, string> = {
+  "en preparacion": "En preparación",
+  enviado: "Enviado",
+  entregado: "Entregado",
+};
+
+function PriceSkeleton() {
+  return (
+    <div className="space-y-3">
+      {[1, 2, 3].map((i) => (
+        <div key={i} className="flex justify-between">
+          <div className="h-4 w-24 rounded bg-brand-accent/10 animate-pulse" />
+          <div className="h-4 w-16 rounded bg-brand-accent/10 animate-pulse" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function PaymentSkeleton() {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+      {[1, 2].map((i) => (
+        <div key={i} className="h-24 rounded-xl bg-brand-accent/5 animate-pulse" />
+      ))}
+    </div>
+  );
+}
+
+function DeliverySkeleton() {
+  return (
+    <div className="space-y-4">
+      <div className="flex gap-6">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="flex items-center gap-2">
+            <div className="w-3 h-3 rounded-full bg-brand-accent/10 animate-pulse" />
+            <div className="h-3 w-16 rounded bg-brand-accent/10 animate-pulse" />
+          </div>
+        ))}
+      </div>
+      <div className="space-y-2">
+        <div className="h-4 w-48 rounded bg-brand-accent/10 animate-pulse" />
+        <div className="h-4 w-64 rounded bg-brand-accent/10 animate-pulse" />
+      </div>
+    </div>
+  );
+}
+
+function MiniTarjetaCard({ monto, ultimos_cuatro_digitos, nombre_titular }: { monto: number; ultimos_cuatro_digitos: string; nombre_titular: string | null }) {
+  return (
+    <div className="relative overflow-hidden rounded-xl border border-brand-accent/15 bg-gradient-to-br from-white to-brand-bg p-4 shadow-sm">
+      <div className="absolute top-0 right-0 w-20 h-20 bg-brand-primary/5 rounded-bl-full" />
+      <div className="relative flex items-start justify-between mb-4">
+        <div className="w-9 h-6 rounded bg-gradient-to-br from-brand-accent/40 to-brand-accent/20 shadow-inner" />
+        <CreditCard className="w-4 h-4 text-brand-accent/40" />
+      </div>
+      <div className="relative space-y-1">
+        <p className="font-mono text-sm tracking-wider text-brand-text">
+          **** **** **** {ultimos_cuatro_digitos}
+        </p>
+        <div className="flex items-center justify-between">
+          <p className="text-xs text-brand-secondary truncate">
+            {nombre_titular || "Titular"}
+          </p>
+          <p className="text-sm font-bold text-brand-primary">
+            {formatPrecio(monto)}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DeliveryTimeline({ estado }: { estado: string }) {
+  const currentIndex = DELIVERY_STEPS.indexOf(estado as typeof DELIVERY_STEPS[number]);
+
+  return (
+    <div className="flex items-center gap-0">
+      {DELIVERY_STEPS.map((step, index) => {
+        const isCompleted = index <= currentIndex;
+        const isCurrent = index === currentIndex;
+
+        return (
+          <div key={step} className="flex items-center">
+            <div className="flex flex-col items-center gap-1.5">
+              <div
+                className={`w-3 h-3 rounded-full border-2 transition-colors ${
+                  isCompleted
+                    ? "bg-success border-success"
+                    : "bg-transparent border-brand-accent/30"
+                } ${isCurrent ? "ring-2 ring-success/20" : ""}`}
+              />
+              <span
+                className={`text-[11px] font-medium whitespace-nowrap ${
+                  isCurrent
+                    ? "text-brand-text"
+                    : isCompleted
+                      ? "text-success"
+                      : "text-brand-accent/50"
+                }`}
+              >
+                {STEP_LABELS[step]}
+              </span>
+            </div>
+            {index < DELIVERY_STEPS.length - 1 && (
+              <div
+                className={`w-12 sm:w-16 h-0.5 mx-1 mb-5 ${
+                  index < currentIndex ? "bg-success" : "bg-brand-accent/15"
+                }`}
+              />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export default function CompraDetalleClient({ initialData }: CompraDetalleClientProps) {
+  const [extra, setExtra] = useState<CompraDetalleExtra | null>(null);
+  const [loadingExtra, setLoadingExtra] = useState(true);
+  const [errorExtra, setErrorExtra] = useState(false);
+  const [librosAbiertos, setLibrosAbiertos] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const result = await fetchCompraDetalleExtraAction(initialData.id);
+        if (!cancelled) setExtra(result);
+      } catch {
+        if (!cancelled) setErrorExtra(true);
+      } finally {
+        if (!cancelled) setLoadingExtra(false);
+      }
+    }
+    load();
+    return () => { cancelled = true; };
+  }, [initialData.id]);
+
+  const subtotal = initialData.items.reduce(
+    (sum, item) => sum + item.precio_unitario * item.cantidad,
+    0
+  );
+
+  return (
+    <div className="space-y-6" style={{ animation: "fadeUp 0.5s ease-out both" }}>
+      {/* Back button */}
+      <Link
+        href="/historial-compras"
+        className="inline-flex items-center gap-1.5 text-sm text-brand-secondary hover:text-brand-primary transition-colors"
+      >
+        <ArrowLeft className="w-4 h-4" />
+        Volver al historial
+      </Link>
+
+      {/* Header */}
+      <div
+        className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1 pb-4 border-b border-brand-accent/10"
+        style={{ animation: "fadeUp 0.5s ease-out 0.1s both" }}
+      >
+        <div>
+          <h1 className="text-xl font-display font-semibold text-brand-text">
+            Detalle de Compra
+          </h1>
+          <p className="text-sm text-brand-secondary mt-0.5">
+            {formatFecha(initialData.fecha)}
+          </p>
+        </div>
+        <p className="text-xs font-mono text-brand-accent">
+          #{initialData.id.slice(0, 8)}
+        </p>
+      </div>
+
+      {/* Price breakdown */}
+      <section
+        className="bg-white rounded-xl border border-brand-accent/15 shadow-sm p-5"
+        style={{ animation: "fadeUp 0.5s ease-out 0.3s both" }}
+      >
+        <h2 className="text-sm font-semibold text-brand-text mb-4">
+          Resumen de precios
+        </h2>
+        {loadingExtra ? (
+          <PriceSkeleton />
+        ) : (
+          <div className="space-y-2.5">
+            <div className="flex justify-between text-sm">
+              <span className="text-brand-secondary">Subtotal</span>
+              <span className="text-brand-text">{formatPrecio(subtotal)}</span>
+            </div>
+            {extra?.entrega && (
+              <div className="flex justify-between text-sm">
+                <span className="text-brand-secondary">
+                  Envío ({extra.entrega.tipo === "envio" ? "Delivery" : "Recogida"})
+                </span>
+                <span className="text-brand-text">
+                  {extra.entrega.costo > 0 ? formatPrecio(extra.entrega.costo) : "Gratis"}
+                </span>
+              </div>
+            )}
+            {initialData.id_promocion && (
+              <div className="flex justify-between text-sm">
+                <span className="text-brand-secondary">Promoción</span>
+                <span className="text-success">Aplicada</span>
+              </div>
+            )}
+            <div className="pt-2.5 mt-2.5 border-t border-brand-accent/10 flex justify-between">
+              <span className="text-sm font-semibold text-brand-text">Total</span>
+              <span className="text-base font-bold text-brand-primary">
+                {formatPrecio(initialData.total)}
+              </span>
+            </div>
+          </div>
+        )}
+      </section>
+
+      {/* Payment methods + Delivery side by side on desktop */}
+      <div
+        className="grid grid-cols-1 lg:grid-cols-2 gap-4"
+        style={{ animation: "fadeUp 0.5s ease-out 0.4s both" }}
+      >
+        {/* Payment methods */}
+        <section className="order-2 lg:order-none bg-white rounded-xl border border-brand-accent/15 shadow-sm p-5">
+          <div className="flex items-center gap-2 mb-4">
+            <CreditCard className="w-4 h-4 text-brand-accent" />
+            <h2 className="text-sm font-semibold text-brand-text">
+              Métodos de pago
+            </h2>
+          </div>
+          {loadingExtra ? (
+            <PaymentSkeleton />
+          ) : errorExtra || !extra?.tarjetas?.length ? (
+            <p className="text-xs text-brand-secondary">No hay información de pago disponible.</p>
+          ) : (
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              {extra.tarjetas.map((tarjeta, index) => (
+                <MiniTarjetaCard key={index} {...tarjeta} />
+              ))}
+            </div>
+          )}
+        </section>
+
+        {/* Delivery */}
+        <section className="order-1 lg:order-none bg-white rounded-xl border border-brand-accent/15 shadow-sm p-5">
+          <div className="flex items-center gap-2 mb-4">
+            <Truck className="w-4 h-4 text-brand-accent" />
+            <h2 className="text-sm font-semibold text-brand-text">
+              Estado de entrega
+            </h2>
+          </div>
+          {loadingExtra ? (
+            <DeliverySkeleton />
+          ) : errorExtra || !extra?.entrega ? (
+            <p className="text-xs text-brand-secondary">No hay información de entrega disponible.</p>
+          ) : (
+            <div className="space-y-4">
+              <DeliveryTimeline estado={extra.entrega.estado} />
+
+              <div className="space-y-2 pt-2 border-t border-brand-accent/10">
+                <div className="flex items-center gap-2 text-sm">
+                  <Clock className="w-3.5 h-3.5 text-brand-accent" />
+                  <span className="text-brand-secondary">Estimado:</span>
+                  <span className="text-brand-text font-medium">
+                    {formatFecha(extra.entrega.fecha_entrega_estimada)}
+                  </span>
+                </div>
+                {extra.entrega.fecha_entregado && (
+                  <div className="flex items-center gap-2 text-sm">
+                    <CheckCircle2 className="w-3.5 h-3.5 text-success" />
+                    <span className="text-brand-secondary">Entregado:</span>
+                    <span className="text-brand-text font-medium">
+                      {formatFecha(extra.entrega.fecha_entregado)}
+                    </span>
+                  </div>
+                )}
+                <div className="flex items-start gap-2 text-sm">
+                  <Package className="w-3.5 h-3.5 text-brand-accent mt-0.5" />
+                  <span className="text-brand-secondary">Dirección:</span>
+                  <span className="text-brand-text">{extra.entrega.direccion}</span>
+                </div>
+              </div>
+            </div>
+          )}
+        </section>
+      </div>
+
+      {/* Return request */}
+      <section
+        className="bg-white rounded-xl border border-brand-accent/15 shadow-sm p-5"
+        style={{ animation: "fadeUp 0.5s ease-out 0.5s both" }}
+      >
+        <div className="flex items-start gap-3">
+          <div className="w-9 h-9 rounded-lg bg-brand-bg flex items-center justify-center shrink-0">
+            <RotateCcw className="w-4 h-4 text-brand-accent" />
+          </div>
+          <div className="flex-1">
+            <h2 className="text-sm font-semibold text-brand-text">
+              ¿Problemas con tu compra?
+            </h2>
+            <p className="text-xs text-brand-secondary mt-1 leading-relaxed">
+              Si alguno de tus libros no llegó en buen estado o tienes algún inconveniente, puedes solicitar una devolución.
+            </p>
+            <button
+              disabled
+              className="mt-3 px-4 py-2 text-xs font-medium rounded-lg border border-brand-accent/20 bg-white text-brand-secondary/40 cursor-not-allowed"
+              title="Próximamente disponible"
+            >
+              Solicitar devolución
+            </button>
+          </div>
+        </div>
+      </section>
+
+      {/* Books - Collapsible */}
+      <section
+        className="bg-white rounded-xl border border-brand-accent/15 shadow-sm overflow-hidden"
+        style={{ animation: "fadeUp 0.5s ease-out 0.6s both" }}
+      >
+        <button
+          type="button"
+          onClick={() => setLibrosAbiertos((prev) => !prev)}
+          className="w-full flex items-center justify-between px-5 py-3 text-left hover:bg-brand-bg/50 transition-colors"
+        >
+          <h2 className="text-sm font-semibold text-brand-text">
+            {initialData.items.length} {initialData.items.length === 1 ? "libro" : "libros"}
+          </h2>
+          <ChevronDown
+            className={`w-4 h-4 text-brand-accent transition-transform duration-200 ${
+              librosAbiertos ? "rotate-180" : ""
+            }`}
+          />
+        </button>
+        {librosAbiertos && (
+          <div className="border-t border-brand-accent/10">
+            {initialData.items.map((item, index) => (
+              <CompraItemCard key={item.libro?.id ?? `item-${index}`} item={item} />
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/components/compra/CompraItemCard.tsx
+++ b/components/compra/CompraItemCard.tsx
@@ -29,8 +29,8 @@ export default function CompraItemCard({ item }: CompraItemCardProps) {
         )}
       </div>
 
-      {/* Info + Botones */}
-      <div className="flex-1 flex flex-col justify-between min-w-0">
+      {/* Info */}
+      <div className="flex-1 min-w-0">
         <div className="space-y-1">
           <h3 className="text-sm font-medium text-brand-text line-clamp-2">
             {libro?.titulo || "Título no disponible"}
@@ -48,17 +48,6 @@ export default function CompraItemCard({ item }: CompraItemCardProps) {
               </span>
             )}
           </div>
-        </div>
-
-        {/* Botón deshabilitado */}
-        <div className="mt-2">
-          <button
-            disabled
-            className="px-3 py-1.5 text-xs font-medium rounded-lg border border-brand-accent/20 bg-white text-brand-secondary/40 cursor-not-allowed"
-            title="Próximamente"
-          >
-            Devolución
-          </button>
         </div>
       </div>
     </div>

--- a/lib/types/compra.ts
+++ b/lib/types/compra.ts
@@ -58,3 +58,28 @@ export interface CompraConItems {
 
 /** Response paginado de compras con items. */
 export type CompraHistorialResponse = Paginated<CompraConItems>;
+
+// ─── Tipos para detalle de compra ──────────────────────────────────
+
+/** Tarjeta usada en una compra (info segura para el cliente). */
+export interface CompraTarjetaInfo {
+  monto: number;
+  ultimos_cuatro_digitos: string;
+  nombre_titular: string | null;
+}
+
+/** Información de entrega de una compra. */
+export interface CompraEntregaInfo {
+  tipo: string;
+  estado: string;
+  costo: number;
+  fecha_entrega_estimada: string;
+  fecha_entregado: string | null;
+  direccion: string;
+}
+
+/** Datos extra de una compra: tarjetas y entrega. */
+export interface CompraDetalleExtra {
+  tarjetas: CompraTarjetaInfo[];
+  entrega: CompraEntregaInfo | null;
+}

--- a/models/compraModel.ts
+++ b/models/compraModel.ts
@@ -9,6 +9,9 @@ import type {
   CompraConItems,
   CompraItem,
   CompraHistorialResponse,
+  CompraDetalleExtra,
+  CompraTarjetaInfo,
+  CompraEntregaInfo,
 } from "@/lib/types/compra";
 
 function buildQueryOptions(page: number, pageSize: number) {
@@ -201,24 +204,120 @@ export async function getCompraById(
 }
 
 /**
- * Checks if a compra exists by ID. Used for FK validation.
+ * Gets a single compra with its items enriched (book info + cover images).
+ * Returns null if not found.
  */
-export async function checkCompraExistsById(
+export async function getCompraDetalleById(
   id: string
-): Promise<boolean> {
+): Promise<CompraConItems | null> {
   const adminClient = createAdminClient();
 
   const { data, error } = await adminClient
     .from("compra")
-    .select("id")
+    .select(
+      `
+      *,
+      items:item_compra(
+        id,
+        id_copia,
+        copia(
+          id_libro,
+          libro(
+            id,
+            titulo,
+            precio,
+            editorial,
+            idioma,
+            noticias(
+              imagenes,
+              deleted_at,
+              es_visible
+            )
+          )
+        )
+      )
+    `
+    )
     .eq("id", id)
-    .limit(1)
     .maybeSingle();
 
   if (error) {
-    console.error("[compraModel] Error al verificar existencia de compra por ID:", error);
+    console.error("[compraModel] Error al obtener detalle de compra:", error);
     throw error;
   }
 
-  return !!data;
+  if (!data) return null;
+
+  const [compra] = transformCompras([data]);
+  return compra ?? null;
+}
+
+type RawTarjetaCompraRow = {
+  monto: number;
+  tarjeta: { ultimos_cuatro_digitos: string; nombre_titular: string | null } | null;
+};
+
+type RawEntregaRow = {
+  tipo: string;
+  estado: string;
+  costo: number;
+  fecha_entrega_estimada: string;
+  fecha_entregado: string | null;
+  direccion: { direccion_formateada: string } | null;
+};
+
+function mapTarjetas(data: RawTarjetaCompraRow[]): CompraTarjetaInfo[] {
+  return data.map((t) => ({
+    monto: t.monto,
+    ultimos_cuatro_digitos: t.tarjeta?.ultimos_cuatro_digitos ?? "****",
+    nombre_titular: t.tarjeta?.nombre_titular ?? null,
+  }));
+}
+
+function mapEntrega(raw: RawEntregaRow): CompraEntregaInfo {
+  return {
+    tipo: raw.tipo,
+    estado: raw.estado,
+    costo: raw.costo,
+    fecha_entrega_estimada: raw.fecha_entrega_estimada,
+    fecha_entregado: raw.fecha_entregado,
+    direccion: raw.direccion?.direccion_formateada ?? "Sin dirección",
+  };
+}
+
+/**
+ * Gets extra detail for a compra: payment cards and delivery info.
+ * Returns null if the compra has no associated records or is not found.
+ */
+export async function getCompraDetalleExtraById(
+  id: string
+): Promise<CompraDetalleExtra> {
+  const adminClient = createAdminClient();
+
+  const [tarjetasResult, entregaResult] = await Promise.all([
+    adminClient
+      .from("tarjeta_compra")
+      .select("monto, tarjeta(ultimos_cuatro_digitos, nombre_titular)")
+      .eq("id_compra", id),
+    adminClient
+      .from("entrega")
+      .select("tipo, estado, costo, fecha_entrega_estimada, fecha_entregado, direccion:direccion(direccion_formateada)")
+      .eq("id_compra", id)
+      .maybeSingle(),
+  ]);
+
+  if (tarjetasResult.error) {
+    console.error("[compraModel] Error al obtener tarjetas de compra:", tarjetasResult.error);
+    throw tarjetasResult.error;
+  }
+
+  if (entregaResult.error) {
+    console.error("[compraModel] Error al obtener entrega de compra:", entregaResult.error);
+    throw entregaResult.error;
+  }
+
+  const tarjetas = mapTarjetas((tarjetasResult.data ?? []) as RawTarjetaCompraRow[]);
+  const entrega = entregaResult.data ? mapEntrega(entregaResult.data as unknown as RawEntregaRow) : null;
+
+  return { tarjetas, entrega };
 }

--- a/services/compra/compraService.ts
+++ b/services/compra/compraService.ts
@@ -1,4 +1,10 @@
-import { createCompra, getComprasByUserId } from "@/models/compraModel";
+import {
+  createCompra,
+  getComprasByUserId,
+  getCompraById,
+  getCompraDetalleById,
+  getCompraDetalleExtraById,
+} from "@/models/compraModel";
 import { insertItemComprasBatch } from "@/models/itemCompraModel";
 import { insertTarjetaComprasBatch } from "@/models/tarjetaCompraModel";
 import { insertEntrega } from "@/models/entregaModel";
@@ -14,7 +20,12 @@ import {
 import { getCurrentUser } from "@/models/authModel";
 import { createAdminClient } from "@/lib/supabase/server";
 import { getErrorMessage } from "@/lib/services/errors";
-import type { CompraListParams, CompraHistorialResponse } from "@/lib/types/compra";
+import type {
+  CompraListParams,
+  CompraHistorialResponse,
+  CompraConItems,
+  CompraDetalleExtra,
+} from "@/lib/types/compra";
 
 export interface RegistrarCompraInput {
   id_usuario: string;
@@ -267,12 +278,32 @@ export async function registrarCompra(
 
 // ─── Lectura ───────────────────────────────────────────────────────
 
+async function verificarOwnershipCompra(
+  idCompra: string,
+): Promise<{ userId: string } | null> {
+  const user = await getCurrentUser();
+  if (!user) {
+    console.error("[compraService] No hay sesión activa.");
+    return null;
+  }
+
+  const raw = await getCompraById(idCompra);
+  if (!raw || raw.id_usuario !== user.id) {
+    console.error(
+      "[compraService] La compra no pertenece al usuario autenticado.",
+    );
+    return null;
+  }
+
+  return { userId: user.id };
+}
+
 /**
  * Obtiene el historial de compras del usuario autenticado de forma paginada.
  * Filtra por userId de la sesión activa, con soporte de rango de fechas.
  */
 export async function obtenerHistorialCompras(
-  params: CompraListParams
+  params: CompraListParams,
 ): Promise<CompraHistorialResponse> {
   const emptyResult: CompraHistorialResponse = {
     data: [],
@@ -291,7 +322,55 @@ export async function obtenerHistorialCompras(
 
     return await getComprasByUserId(user.id, params);
   } catch (error) {
-    console.error("[compraService] Error obteniendo historial de compras:", error);
+    console.error(
+      "[compraService] Error obteniendo historial de compras:",
+      error,
+    );
     return emptyResult;
   }
+}
+
+async function ejecutarConOwnership<T>(
+  idCompra: string,
+  fn: () => Promise<T>,
+  label: string,
+): Promise<T | null> {
+  try {
+    const ownership = await verificarOwnershipCompra(idCompra);
+    if (!ownership) return null;
+    return await fn();
+  } catch (error) {
+    console.error(`[compraService] Error ${label}:`, error);
+    return null;
+  }
+}
+
+/**
+ * Obtiene el detalle de una compra específica (compra + items enriquecidos).
+ * Verifica que la compra pertenezca al usuario autenticado.
+ * Retorna null si no hay sesión, la compra no existe o no pertenece al usuario.
+ */
+export function obtenerDetalleCompra(
+  idCompra: string,
+): Promise<CompraConItems | null> {
+  return ejecutarConOwnership(
+    idCompra,
+    () => getCompraDetalleById(idCompra),
+    "obteniendo detalle de compra",
+  );
+}
+
+/**
+ * Obtiene los datos extra de una compra: tarjetas de pago y estado de entrega.
+ * Verifica que la compra pertenezca al usuario autenticado.
+ * Retorna null si no hay sesión o la compra no pertenece al usuario.
+ */
+export function obtenerDetalleExtra(
+  idCompra: string,
+): Promise<CompraDetalleExtra | null> {
+  return ejecutarConOwnership(
+    idCompra,
+    () => getCompraDetalleExtraById(idCompra),
+    "obteniendo detalle extra de compra",
+  );
 }


### PR DESCRIPTION
…livery info

- Add dynamic route /historial-compras/[id] with server component
- Add CompraDetalleClient with price breakdown, payment cards (mini cards), delivery timeline, return request section, and collapsible books list
- Add model functions: getCompraDetalleById, getCompraDetalleExtraById
- Add service functions: obtenerDetalleCompra, obtenerDetalleExtra with ownership verification
- Add actions: fetchCompraDetalleAction, fetchCompraDetalleExtraAction
- Enable 'Ver detalle de compra' link in CompraCard
- Remove individual 'Devolución' buttons from CompraItemCard
- Refactor: extract verificarOwnershipCompra and ejecutarConOwnership to eliminate duplication
- Refactor: remove unused checkCompraExistsById, simplify type casting in model