### PR TITLE
feat(compras): add monto to item_compra and improve purchase detail UX

### DIFF
--- a/app/(with-navbar)/checkout/ConfirmacionStep.tsx
+++ b/app/(with-navbar)/checkout/ConfirmacionStep.tsx
@@ -59,7 +59,7 @@ function getTipoTexto(envioOpcion: OpcionEnvio | null): string {
 function getCartSummary(cartData: ReservaAgrupadaItem[]) {
   const subtotal = cartData.reduce((s, g) => s + g.precio * g.copias_reservadas, 0)
   const totalArticulos = cartData.reduce((s, g) => s + g.copias_reservadas, 0)
-  const copias = cartData.flatMap((g) => g.reservas.map((r) => ({ id_copia: r.id_copia })))
+  const copias = cartData.flatMap((g) => g.reservas.map((r) => ({ id_copia: r.id_copia, monto: g.precio })))
 
   return { subtotal, totalArticulos, copias }
 }
@@ -69,7 +69,7 @@ function buildTarjetas(
 ): CardDisplay[] {
   return paymentAllocations.map((a) => ({
     id_tarjeta: a.id_tarjeta,
-    ultimos_cuatro_digitos: String(a.id_tarjeta).padStart(4, "0").slice(-4),
+    ultimos_cuatro_digitos: a.ultimos_cuatro_digitos,
     monto: a.monto,
   }))
 }
@@ -84,7 +84,7 @@ function buildConfirmPayload({
 }: {
   subtotal: number
   totalConEnvio: number
-  copias: { id_copia: string }[]
+  copias: { id_copia: string; monto: number }[]
   paymentAllocations: TarjetaPaymentAllocation[]
   envioOpcion: OpcionEnvio
   idTiendaDestino: string
@@ -130,7 +130,7 @@ function useConfirmacionAction({
   envioOpcion: OpcionEnvio | null
   subtotal: number
   totalConEnvio: number
-  copias: { id_copia: string }[]
+  copias: { id_copia: string; monto: number }[]
   paymentAllocations: TarjetaPaymentAllocation[]
   idTiendaDestino: string
   onPurchaseComplete: () => void

--- a/app/(with-navbar)/checkout/PagoStep.tsx
+++ b/app/(with-navbar)/checkout/PagoStep.tsx
@@ -150,7 +150,14 @@ export default function PagoStep({
 
     const allocationArray: TarjetaPaymentAllocation[] = Array.from(
       allocations.entries(),
-    ).map(([id_tarjeta, monto]) => ({ id_tarjeta, monto }));
+    ).map(([id_tarjeta, monto]) => {
+      const tarjeta = allTarjetas.find((t) => t.id === id_tarjeta);
+      return {
+        id_tarjeta,
+        monto,
+        ultimos_cuatro_digitos: tarjeta?.ultimos_cuatro_digitos ?? "****",
+      };
+    });
 
     setSubmitting(true);
     const validation = await validatePaymentAllocationAction(

--- a/app/(with-navbar)/checkout/actions.ts
+++ b/app/(with-navbar)/checkout/actions.ts
@@ -237,7 +237,7 @@ export async function validatePaymentAllocationAction(
 export interface ConfirmarCompraActionInput {
   subtotal: number
   total: number
-  copias: { id_copia: string }[]
+  copias: { id_copia: string; monto: number }[]
   tarjetas: { id_tarjeta: number; monto: number }[]
   entrega: {
     tipo: "domicilio" | "recogida" | "traslado"

--- a/components/compra/CompraDetalleClient.tsx
+++ b/components/compra/CompraDetalleClient.tsx
@@ -2,7 +2,16 @@
 
 import { useState, useEffect } from "react";
 import Link from "next/link";
-import { ArrowLeft, CreditCard, Truck, CheckCircle2, Clock, Package, ChevronDown, RotateCcw } from "lucide-react";
+import {
+  ArrowLeft,
+  CreditCard,
+  Truck,
+  CheckCircle2,
+  Clock,
+  Package,
+  ChevronDown,
+  RotateCcw,
+} from "lucide-react";
 import CompraItemCard from "./CompraItemCard";
 import { fetchCompraDetalleExtraAction } from "@/app/(with-navbar)/historial-compras/actions";
 import { formatPrecio } from "@/lib/utils/format";
@@ -45,7 +54,10 @@ function PaymentSkeleton() {
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
       {[1, 2].map((i) => (
-        <div key={i} className="h-24 rounded-xl bg-brand-accent/5 animate-pulse" />
+        <div
+          key={i}
+          className="h-24 rounded-xl bg-brand-accent/5 animate-pulse"
+        />
       ))}
     </div>
   );
@@ -70,7 +82,15 @@ function DeliverySkeleton() {
   );
 }
 
-function MiniTarjetaCard({ monto, ultimos_cuatro_digitos, nombre_titular }: { monto: number; ultimos_cuatro_digitos: string; nombre_titular: string | null }) {
+function MiniTarjetaCard({
+  monto,
+  ultimos_cuatro_digitos,
+  nombre_titular,
+}: {
+  monto: number;
+  ultimos_cuatro_digitos: string;
+  nombre_titular: string | null;
+}) {
   return (
     <div className="relative overflow-hidden rounded-xl border border-brand-accent/15 bg-gradient-to-br from-white to-brand-bg p-4 shadow-sm">
       <div className="absolute top-0 right-0 w-20 h-20 bg-brand-primary/5 rounded-bl-full" />
@@ -96,7 +116,9 @@ function MiniTarjetaCard({ monto, ultimos_cuatro_digitos, nombre_titular }: { mo
 }
 
 function DeliveryTimeline({ estado }: { estado: string }) {
-  const currentIndex = DELIVERY_STEPS.indexOf(estado as typeof DELIVERY_STEPS[number]);
+  const currentIndex = DELIVERY_STEPS.indexOf(
+    estado as (typeof DELIVERY_STEPS)[number],
+  );
 
   return (
     <div className="flex items-center gap-0">
@@ -121,8 +143,7 @@ function DeliveryTimeline({ estado }: { estado: string }) {
                     : isCompleted
                       ? "text-success"
                       : "text-brand-accent/50"
-                }`}
-              >
+                }`}>
                 {STEP_LABELS[step]}
               </span>
             </div>
@@ -140,11 +161,14 @@ function DeliveryTimeline({ estado }: { estado: string }) {
   );
 }
 
-export default function CompraDetalleClient({ initialData }: CompraDetalleClientProps) {
+export default function CompraDetalleClient({
+  initialData,
+}: CompraDetalleClientProps) {
   const [extra, setExtra] = useState<CompraDetalleExtra | null>(null);
   const [loadingExtra, setLoadingExtra] = useState(true);
   const [errorExtra, setErrorExtra] = useState(false);
   const [librosAbiertos, setLibrosAbiertos] = useState(false);
+  const [subtotalAbierto, setSubtotalAbierto] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -159,21 +183,24 @@ export default function CompraDetalleClient({ initialData }: CompraDetalleClient
       }
     }
     load();
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+    };
   }, [initialData.id]);
 
   const subtotal = initialData.items.reduce(
     (sum, item) => sum + item.precio_unitario * item.cantidad,
-    0
+    0,
   );
 
   return (
-    <div className="space-y-6" style={{ animation: "fadeUp 0.5s ease-out both" }}>
+    <div
+      className="space-y-6"
+      style={{ animation: "fadeUp 0.5s ease-out both" }}>
       {/* Back button */}
       <Link
         href="/historial-compras"
-        className="inline-flex items-center gap-1.5 text-sm text-brand-secondary hover:text-brand-primary transition-colors"
-      >
+        className="inline-flex items-center gap-1.5 text-sm text-brand-secondary hover:text-brand-primary transition-colors">
         <ArrowLeft className="w-4 h-4" />
         Volver al historial
       </Link>
@@ -181,8 +208,7 @@ export default function CompraDetalleClient({ initialData }: CompraDetalleClient
       {/* Header */}
       <div
         className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1 pb-4 border-b border-brand-accent/10"
-        style={{ animation: "fadeUp 0.5s ease-out 0.1s both" }}
-      >
+        style={{ animation: "fadeUp 0.5s ease-out 0.1s both" }}>
         <div>
           <h1 className="text-xl font-display font-semibold text-brand-text">
             Detalle de Compra
@@ -199,8 +225,7 @@ export default function CompraDetalleClient({ initialData }: CompraDetalleClient
       {/* Price breakdown */}
       <section
         className="bg-white rounded-xl border border-brand-accent/15 shadow-sm p-5"
-        style={{ animation: "fadeUp 0.5s ease-out 0.3s both" }}
-      >
+        style={{ animation: "fadeUp 0.5s ease-out 0.3s both" }}>
         <h2 className="text-sm font-semibold text-brand-text mb-4">
           Resumen de precios
         </h2>
@@ -208,17 +233,50 @@ export default function CompraDetalleClient({ initialData }: CompraDetalleClient
           <PriceSkeleton />
         ) : (
           <div className="space-y-2.5">
-            <div className="flex justify-between text-sm">
-              <span className="text-brand-secondary">Subtotal</span>
-              <span className="text-brand-text">{formatPrecio(subtotal)}</span>
+            <div>
+              <button
+                type="button"
+                onClick={() => setSubtotalAbierto((prev) => !prev)}
+                className="w-full flex items-center justify-between text-sm hover:bg-brand-bg/50 rounded-lg py-1 transition-colors">
+                <span className="text-brand-secondary flex items-center gap-1.5">
+                  Subtotal
+                  <ChevronDown
+                    className={`w-3.5 h-3.5 transition-transform duration-200 ${
+                      subtotalAbierto ? "rotate-180" : ""
+                    }`}
+                  />
+                </span>
+                <span className="text-brand-text font-medium">
+                  {formatPrecio(subtotal)}
+                </span>
+              </button>
+              {subtotalAbierto && (
+                <div className="mt-2 ml-2 pl-3 border-l-2 border-brand-accent/15 space-y-1.5">
+                  {initialData.items.map((item, idx) => (
+                    <div
+                      key={item.libro?.id ?? idx}
+                      className="flex items-center justify-between text-xs">
+                      <span className="text-brand-secondary truncate max-w-[70%]">
+                        {item.libro?.titulo ?? "Libro"} × {item.cantidad}
+                      </span>
+                      <span className="text-brand-text font-medium">
+                        {formatPrecio(item.precio_unitario * item.cantidad)}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
             </div>
             {extra?.entrega && (
               <div className="flex justify-between text-sm">
                 <span className="text-brand-secondary">
-                  Envío ({extra.entrega.tipo === "envio" ? "Delivery" : "Recogida"})
+                  Envío (
+                  {extra.entrega.tipo === "envio" ? "Delivery" : "Recogida"})
                 </span>
                 <span className="text-brand-text">
-                  {extra.entrega.costo > 0 ? formatPrecio(extra.entrega.costo) : "Gratis"}
+                  {extra.entrega.costo > 0
+                    ? formatPrecio(extra.entrega.costo)
+                    : "Gratis"}
                 </span>
               </div>
             )}
@@ -229,7 +287,9 @@ export default function CompraDetalleClient({ initialData }: CompraDetalleClient
               </div>
             )}
             <div className="pt-2.5 mt-2.5 border-t border-brand-accent/10 flex justify-between">
-              <span className="text-sm font-semibold text-brand-text">Total</span>
+              <span className="text-sm font-semibold text-brand-text">
+                Total
+              </span>
               <span className="text-base font-bold text-brand-primary">
                 {formatPrecio(initialData.total)}
               </span>
@@ -241,8 +301,7 @@ export default function CompraDetalleClient({ initialData }: CompraDetalleClient
       {/* Payment methods + Delivery side by side on desktop */}
       <div
         className="grid grid-cols-1 lg:grid-cols-2 gap-4"
-        style={{ animation: "fadeUp 0.5s ease-out 0.4s both" }}
-      >
+        style={{ animation: "fadeUp 0.5s ease-out 0.4s both" }}>
         {/* Payment methods */}
         <section className="order-2 lg:order-none bg-white rounded-xl border border-brand-accent/15 shadow-sm p-5">
           <div className="flex items-center gap-2 mb-4">
@@ -254,7 +313,9 @@ export default function CompraDetalleClient({ initialData }: CompraDetalleClient
           {loadingExtra ? (
             <PaymentSkeleton />
           ) : errorExtra || !extra?.tarjetas?.length ? (
-            <p className="text-xs text-brand-secondary">No hay información de pago disponible.</p>
+            <p className="text-xs text-brand-secondary">
+              No hay información de pago disponible.
+            </p>
           ) : (
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
               {extra.tarjetas.map((tarjeta, index) => (
@@ -275,7 +336,9 @@ export default function CompraDetalleClient({ initialData }: CompraDetalleClient
           {loadingExtra ? (
             <DeliverySkeleton />
           ) : errorExtra || !extra?.entrega ? (
-            <p className="text-xs text-brand-secondary">No hay información de entrega disponible.</p>
+            <p className="text-xs text-brand-secondary">
+              No hay información de entrega disponible.
+            </p>
           ) : (
             <div className="space-y-4">
               <DeliveryTimeline estado={extra.entrega.estado} />
@@ -300,7 +363,9 @@ export default function CompraDetalleClient({ initialData }: CompraDetalleClient
                 <div className="flex items-start gap-2 text-sm">
                   <Package className="w-3.5 h-3.5 text-brand-accent mt-0.5" />
                   <span className="text-brand-secondary">Dirección:</span>
-                  <span className="text-brand-text">{extra.entrega.direccion}</span>
+                  <span className="text-brand-text">
+                    {extra.entrega.direccion}
+                  </span>
                 </div>
               </div>
             </div>
@@ -311,8 +376,7 @@ export default function CompraDetalleClient({ initialData }: CompraDetalleClient
       {/* Return request */}
       <section
         className="bg-white rounded-xl border border-brand-accent/15 shadow-sm p-5"
-        style={{ animation: "fadeUp 0.5s ease-out 0.5s both" }}
-      >
+        style={{ animation: "fadeUp 0.5s ease-out 0.5s both" }}>
         <div className="flex items-start gap-3">
           <div className="w-9 h-9 rounded-lg bg-brand-bg flex items-center justify-center shrink-0">
             <RotateCcw className="w-4 h-4 text-brand-accent" />
@@ -322,13 +386,13 @@ export default function CompraDetalleClient({ initialData }: CompraDetalleClient
               ¿Problemas con tu compra?
             </h2>
             <p className="text-xs text-brand-secondary mt-1 leading-relaxed">
-              Si alguno de tus libros no llegó en buen estado o tienes algún inconveniente, puedes solicitar una devolución.
+              Si alguno de tus libros no llegó en buen estado o tienes algún
+              inconveniente, puedes solicitar una devolución.
             </p>
             <button
               disabled
               className="mt-3 px-4 py-2 text-xs font-medium rounded-lg border border-brand-accent/20 bg-white text-brand-secondary/40 cursor-not-allowed"
-              title="Próximamente disponible"
-            >
+              title="Próximamente disponible">
               Solicitar devolución
             </button>
           </div>
@@ -338,15 +402,14 @@ export default function CompraDetalleClient({ initialData }: CompraDetalleClient
       {/* Books - Collapsible */}
       <section
         className="bg-white rounded-xl border border-brand-accent/15 shadow-sm overflow-hidden"
-        style={{ animation: "fadeUp 0.5s ease-out 0.6s both" }}
-      >
+        style={{ animation: "fadeUp 0.5s ease-out 0.6s both" }}>
         <button
           type="button"
           onClick={() => setLibrosAbiertos((prev) => !prev)}
-          className="w-full flex items-center justify-between px-5 py-3 text-left hover:bg-brand-bg/50 transition-colors"
-        >
+          className="w-full flex items-center justify-between px-5 py-3 text-left hover:bg-brand-bg/50 transition-colors">
           <h2 className="text-sm font-semibold text-brand-text">
-            {initialData.items.length} {initialData.items.length === 1 ? "libro" : "libros"}
+            {initialData.items.length}{" "}
+            {initialData.items.length === 1 ? "libro" : "libros"}
           </h2>
           <ChevronDown
             className={`w-4 h-4 text-brand-accent transition-transform duration-200 ${
@@ -357,7 +420,10 @@ export default function CompraDetalleClient({ initialData }: CompraDetalleClient
         {librosAbiertos && (
           <div className="border-t border-brand-accent/10">
             {initialData.items.map((item, index) => (
-              <CompraItemCard key={item.libro?.id ?? `item-${index}`} item={item} />
+              <CompraItemCard
+                key={item.libro?.id ?? `item-${index}`}
+                item={item}
+              />
             ))}
           </div>
         )}

--- a/lib/types/checkout.ts
+++ b/lib/types/checkout.ts
@@ -50,6 +50,7 @@ export interface DisponibilidadLibroTienda {
 export interface TarjetaPaymentAllocation {
   id_tarjeta: number
   monto: number
+  ultimos_cuatro_digitos: string
 }
 
 export interface TarjetaConSaldo {

--- a/lib/types/itemCompra.ts
+++ b/lib/types/itemCompra.ts
@@ -5,4 +5,5 @@ export type ItemCompraRow = Database["public"]["Tables"]["item_compra"]["Row"];
 export interface ItemCompraCreateInput {
   id_compra: string;
   id_copia: string;
+  monto: number;
 }

--- a/lib/types/supabase.ts
+++ b/lib/types/supabase.ts
@@ -99,7 +99,7 @@ export type Database = {
           fecha: string
           id?: string
           id_promocion?: number | null
-          id_usuario: string
+          id_usuario?: string
           subtotal: number
           total: number
         }
@@ -197,14 +197,14 @@ export type Database = {
           estado: Database["public"]["Enums"]["estado_devolucion"]
           fecha: string
           id?: number
-          id_usuario: string
+          id_usuario?: string | null
         }
         Update: {
           deleted_at?: string | null
           estado?: Database["public"]["Enums"]["estado_devolucion"]
           fecha?: string
           id?: number
-          id_usuario?: string
+          id_usuario?: string | null
         }
         Relationships: [
           {
@@ -409,16 +409,19 @@ export type Database = {
           id: number
           id_compra: string
           id_copia: string
+          monto: number
         }
         Insert: {
           id?: number
           id_compra: string
           id_copia: string
+          monto?: number
         }
         Update: {
           id?: number
           id_compra?: string
           id_copia?: string
+          monto?: number
         }
         Relationships: [
           {
@@ -884,7 +887,7 @@ export type Database = {
           mes_caducidad: number
           nombre_titular?: string | null
           saldo: number
-          ultimos_cuatro_digitos: string
+          ultimos_cuatro_digitos?: string
         }
         Update: {
           ano_caducidad?: number

--- a/models/compraModel.ts
+++ b/models/compraModel.ts
@@ -50,7 +50,7 @@ function extractCoverImage(
 }
 
 function groupItemsByLibro(
-  rawItems: { copia?: { libro?: { id: string; titulo: string; precio: number; editorial: string; idioma: string; noticias?: { imagenes: unknown; deleted_at: string | null; es_visible: boolean }[] } } }[]
+  rawItems: { monto: number; copia?: { libro?: { id: string; titulo: string; precio: number; editorial: string; idioma: string; noticias?: { imagenes: unknown; deleted_at: string | null; es_visible: boolean }[] } } }[]
 ): CompraItem[] {
   const grouped = new Map<string, CompraItem>();
 
@@ -58,11 +58,12 @@ function groupItemsByLibro(
     const libro = raw.copia?.libro;
     if (!libro) continue;
 
-    const existing = grouped.get(libro.id);
+    const key = `${libro.id}__${raw.monto}`;
+    const existing = grouped.get(key);
     if (existing) {
       existing.cantidad++;
     } else {
-      grouped.set(libro.id, {
+      grouped.set(key, {
         libro: {
           id: libro.id,
           titulo: libro.titulo,
@@ -72,7 +73,7 @@ function groupItemsByLibro(
         },
         cantidad: 1,
         imagen_portada: extractCoverImage(libro.noticias),
-        precio_unitario: libro.precio,
+        precio_unitario: raw.monto,
       });
     }
   }
@@ -89,7 +90,7 @@ function transformCompras(
     subtotal: compra.subtotal,
     total: compra.total,
     id_promocion: compra.id_promocion,
-    items: groupItemsByLibro(compra.items as { copia?: { libro?: { id: string; titulo: string; precio: number; editorial: string; idioma: string; noticias?: { imagenes: unknown; deleted_at: string | null; es_visible: boolean }[] } } }[]),
+    items: groupItemsByLibro(compra.items as { monto: number; copia?: { libro?: { id: string; titulo: string; precio: number; editorial: string; idioma: string; noticias?: { imagenes: unknown; deleted_at: string | null; es_visible: boolean }[] } } }[]),
   }));
 }
 
@@ -140,6 +141,7 @@ export async function getComprasByUserId(
       items:item_compra(
         id,
         id_copia,
+        monto,
         copia(
           id_libro,
           libro(
@@ -220,6 +222,7 @@ export async function getCompraDetalleById(
       items:item_compra(
         id,
         id_copia,
+        monto,
         copia(
           id_libro,
           libro(

--- a/services/compra/compraService.ts
+++ b/services/compra/compraService.ts
@@ -32,7 +32,7 @@ export interface RegistrarCompraInput {
   subtotal: number;
   total: number;
   id_promocion?: number | null;
-  copias: { id_copia: string }[];
+  copias: { id_copia: string; monto: number }[];
   tarjetas: { id_tarjeta: number; monto: number }[];
   entrega: {
     tipo: "envio" | "recogida";
@@ -128,6 +128,17 @@ function validateMontoTotal(
   return { ok: true };
 }
 
+function validateSubtotal(
+  copias: { id_copia: string; monto: number }[],
+  subtotal: number,
+): { ok: true } | { ok: false; errors: Record<string, string> } {
+  const sumCopias = copias.reduce((sum, c) => sum + c.monto, 0);
+  if (sumCopias !== subtotal) {
+    return { ok: false, errors: { subtotal: "SUBTOTAL_MISMATCH" } };
+  }
+  return { ok: true };
+}
+
 async function restoreDeducciones(
   deducciones: { id_tarjeta: number; monto: number }[],
 ): Promise<void> {
@@ -195,7 +206,7 @@ async function executeWrites(
     created.compraId = compra.id;
 
     const items = await insertItemComprasBatch(
-      input.copias.map((c) => ({ id_compra: compra.id, id_copia: c.id_copia })),
+      input.copias.map((c) => ({ id_compra: compra.id, id_copia: c.id_copia, monto: c.monto })),
     );
     created.itemCompraIds = items.map((i) => i.id);
 
@@ -260,6 +271,11 @@ export async function registrarCompra(
   const montoCheck = validateMontoTotal(input.tarjetas, input.total);
   if (!montoCheck.ok) {
     return { success: false, errors: montoCheck.errors };
+  }
+
+  const subtotalCheck = validateSubtotal(input.copias, input.subtotal);
+  if (!subtotalCheck.ok) {
+    return { success: false, errors: subtotalCheck.errors };
   }
 
   try {

--- a/supabase/migrations/20260603_add_monto_to_item_compra.sql
+++ b/supabase/migrations/20260603_add_monto_to_item_compra.sql
@@ -1,0 +1,2 @@
+ALTER TABLE item_compra
+ADD COLUMN monto numeric(10,2) NOT NULL DEFAULT 0;

--- a/supabase/migrations/20260603_backfill_monto_item_compra.sql
+++ b/supabase/migrations/20260603_backfill_monto_item_compra.sql
@@ -1,0 +1,5 @@
+UPDATE item_compra ic
+SET monto = l.precio
+FROM copia c
+JOIN libro l ON l.id = c.id_libro
+WHERE c.id = ic.id_copia;


### PR DESCRIPTION
- Add monto column to item_compra to snapshot price at purchase time
- Backfill existing items with libro.precio via migration
- Add validateSubtotal() to ensure copias monto matches subtotal
- Fix groupItemsByLibro to handle same book with different prices
- Fix buildTarjetas to show real last 4 digits from card data
- Make subtotal collapsible in purchase detail with per-item breakdown
- Enrich TarjetaPaymentAllocation with ultimos_cuatro_digitos